### PR TITLE
Optimization/reconfigure

### DIFF
--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -277,7 +277,9 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
       _data.discountRate
     );
 
+    //TODO this shit doesn't change often. Is is necessary to write a new version of it to storage each reconfig?
     // Set the metadata if needed.
+    // if (_metadata > 0) _metadataOf[_projectId][_configuration] = _metadata;
     if (_metadata > 0) _metadataOf[_projectId][_configuration] = _metadata;
 
     emit Configure(_configuration, _projectId, _data, _metadata, msg.sender);
@@ -498,6 +500,8 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     // If all properties are zero, no need to store anything as the default value will have the same outcome.
     if (_ballot == IJBFundingCycleBallot(address(0)) && _duration == 0 && _discountRate == 0)
       return;
+
+    //TODO this shit doesn't change often. Is is necessary to write a new version of it to storage each reconfig?
 
     // ballot in bits 0-159 bytes.
     uint256 packed = uint160(address(_ballot));

--- a/contracts/JBPrices.sol
+++ b/contracts/JBPrices.sol
@@ -9,7 +9,11 @@ import './interfaces/IJBPrices.sol';
   @notice Manages and normalizes price feeds.
 */
 contract JBPrices is IJBPrices, Ownable {
+  error NotFound();
+  error AlreadyExists(uint256 _currency, uint256 _base);
+
   //*********************************************************************//
+
   // ---------------- public constant stored properties ---------------- //
   //*********************************************************************//
 
@@ -53,7 +57,7 @@ contract JBPrices is IJBPrices, Ownable {
     AggregatorV3Interface _feed = feedFor[_currency][_base];
 
     // Feed must exist.
-    require(_feed != AggregatorV3Interface(address(0)), '0x03: NOT_FOUND');
+    if (_feed == AggregatorV3Interface(address(0))) revert NotFound();
 
     // Get the latest round information. Only need the price is needed.
     (, int256 _price, , , ) = _feed.latestRoundData();
@@ -104,7 +108,8 @@ contract JBPrices is IJBPrices, Ownable {
     AggregatorV3Interface _feed
   ) external override onlyOwner {
     // There can't already be a feed for the specified currency.
-    require(feedFor[_currency][_base] == AggregatorV3Interface(address(0)), '0x04: ALREADY_EXISTS');
+    if (feedFor[_currency][_base] != AggregatorV3Interface(address(0)))
+      revert AlreadyExists(_currency, _base);
 
     // Set the feed.
     feedFor[_currency][_base] = _feed;

--- a/contracts/structs/JBConfigurationCurrencyData.sol
+++ b/contracts/structs/JBConfigurationCurrencyData.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBConfigurationCurrencyData {
+  // The configuration during which the new currency was set.
+  uint56 configuration;
+  // The currency that is being configured.
+  uint8 currency;
+}

--- a/contracts/structs/JBConfigurationFundingCycleMetadataData.sol
+++ b/contracts/structs/JBConfigurationFundingCycleMetadataData.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBConfigurationFundingCycleMetadataData {
+  // The configuration during which the new metadata was set.
+  uint56 configuration;
+  // The metadata that is being configured.
+  uint256 metadata;
+}

--- a/contracts/structs/JBConfigurationFundingCyclePackedUserPropertiesData.sol
+++ b/contracts/structs/JBConfigurationFundingCyclePackedUserPropertiesData.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBConfigurationFundingCyclePackedUserPropertiesData {
+  // The packed user properties during which the new currency was set.
+  uint56 configuration;
+  // The packed user properties that is being configured.
+  uint256 packedUserProperties;
+}

--- a/contracts/structs/JBConfigurationOverflowAllowanceData.sol
+++ b/contracts/structs/JBConfigurationOverflowAllowanceData.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBConfigurationOverflowAllowanceData {
+  // The configuration during which the new overflow allowance was set.
+  uint56 configuration;
+  // The overflow allowance that is being configured.
+  uint256 overflowAllowance;
+}

--- a/contracts/structs/JBSplit.sol
+++ b/contracts/structs/JBSplit.sol
@@ -20,5 +20,5 @@ struct JBSplit {
   IJBSplitAllocator allocator;
   // If an allocator is not set but a projectId is set, funds will be sent to the Juicebox treasury belonging to the project who's ID is specified.
   // Resulting tokens will be routed to the beneficiary with the unstaked token prerence respected.
-  uint56 projectId;
+  uint96 projectId;
 }


### PR DESCRIPTION
When a project is reconfiguring its funding cycles, most properties of the reconfiguration remain the same as the previous configuration.

Often times, only the `distributionLimit` is changing, but all metadata (duration, discount rates, currencies, redemption rates, overflow allowances) are staying the same.

This PR suggest a more efficient way to store some funding cycle properties that are assumed to change with less frequency.

The tradeoff is a slightly more expensive transaction to save rarely-updated metadata, and a slightly more convoluted pattern to read and grok.
