### PR TITLE
Configure for negative tests

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,18 @@
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.tabSize": 2
-  }
+  },
+  "eslint.options": {
+      "extensions": [
+          ".js",
+          ".jsx",
+          ".ts",
+          ".tsx"
+      ]
+  },
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,16 +5,11 @@
     "editor.tabSize": 2
   },
   "eslint.options": {
-      "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx"
-      ]
+    "extensions": [".js", ".jsx", ".ts", ".tsx"]
   },
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+    "source.fixAll.eslint": true
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -236,13 +236,14 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
 
     @param _projectId The ID of the project being configured.
     @param _data The funding cycle configuration.
-      @dev _data.target The amount that the project wants to receive in each funding cycle. 18 decimals.
+      @dev _data.target The amount that the project wants to payout during a funding cycle. Sent as a wad (18 decimals).
       @dev _data.duration The duration of the funding cycle for which the `_target` amount is needed. Measured in days. 
         Set to 0 for no expiry and to be able to reconfigure anytime.
       @dev _data.discountRate A number from 0-1000000000 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
         If it's 0, each funding cycle will have equal weight.
-        If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
-        If the number is 1000000001, an non-recurring funding cycle will get made.
+        If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amount during the current funding cycle.
+        If the number is 1000000001, a non-recurring funding cycle will get made.
+      @dev _data.weight A number determining the amount of redistribution shares this funding cycle will issue to each sustainer.
       @dev _data.ballot The new ballot that will be used to approve subsequent reconfigurations.
     @param _metadata Data to associate with this funding cycle configuration.
 

--- a/contracts/structs/JBFundingCycleData.sol
+++ b/contracts/structs/JBFundingCycleData.sol
@@ -4,6 +4,10 @@ pragma solidity 0.8.6;
 import './../interfaces/IJBFundingCycleBallot.sol';
 
 struct JBFundingCycleData {
+  // The amount that this funding cycle is targeting in terms of the currency.
+  uint256 target;
+  // The currency of the `target`. 0 for ETH or 1 for USD.
+  uint256 currency;
   // The duration of the funding cycle in days.
   // A duration of 0 is no duration, meaning projects can trigger a new funding cycle on demand by issueing a reconfiguration.
   uint256 duration;
@@ -19,8 +23,6 @@ struct JBFundingCycleData {
   // If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
   // If the number is 1000000001, an non-recurring funding cycle will get made.
   uint256 discountRate;
-  // The amount that this funding cycle is targeting in terms of the currency.
-  uint256 target;
   // An address of a contract that says whether a proposed reconfiguration should be accepted or rejected.
   IJBFundingCycleBallot ballot;
 }

--- a/contracts/structs/JBFundingCycleData.sol
+++ b/contracts/structs/JBFundingCycleData.sol
@@ -19,6 +19,8 @@ struct JBFundingCycleData {
   // If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
   // If the number is 1000000001, an non-recurring funding cycle will get made.
   uint256 discountRate;
+  // The amount that this funding cycle is targeting in terms of the currency.
+  uint256 target;
   // An address of a contract that says whether a proposed reconfiguration should be accepted or rejected.
   IJBFundingCycleBallot ballot;
 }

--- a/test/jb_funding_cycle_store/configure_for.test.js
+++ b/test/jb_funding_cycle_store/configure_for.test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { deployMockContract } from '@ethereum-waffle/mock-contract';
+
+import jbDirectory from '../../artifacts/contracts/JBDirectory.sol/JBDirectory.json';
+import ijbFundingCycleBallot from '../../artifacts/contracts/interfaces/IJBFundingCycleBallot.sol/IJBFundingCycleBallot.json';
+import { createFundingCycleData } from './utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+describe('JBFundingCycleStore::configureFor(...)', function () {
+  const PROJECT_ID = 2;
+
+  async function setup() {
+    const [deployer, controller, ...addrs] = await ethers.getSigners();
+
+    const mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
+    const mockBallot = await deployMockContract(deployer, ijbFundingCycleBallot.abi);
+    const jbFundingCycleStoreFactory = await ethers.getContractFactory('JBFundingCycleStore');
+    const jbFundingCycleStore = await jbFundingCycleStoreFactory
+      .connect(deployer)
+      .deploy(mockJbDirectory.address);
+    return {
+      controller,
+      mockJbDirectory,
+      mockBallot,
+      jbFundingCycleStore,
+      addrs,
+    };
+  }
+
+  /* Sad path testing */
+
+  it("Should fail if caller is not project's controller", async function () {
+    const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore, addrs } = await setup();
+    const [nonController] = addrs;
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);
+
+    const fundingCycleData = createFundingCycleData({ ballot: mockBallot.address });
+
+    await expect(
+      jbFundingCycleStore.connect(nonController).configureFor(PROJECT_ID, fundingCycleData, 0),
+    ).to.be.revertedWith('0x4f: UNAUTHORIZED');
+  });
+
+  it('Should fail if funding cycle duration is shorter than 1000 seconds', async function () {
+    const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore } = await setup();
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);
+
+    const fundingCycleData = createFundingCycleData({ duration: 999, ballot: mockBallot.address });
+
+    await expect(
+      jbFundingCycleStore.connect(controller).configureFor(PROJECT_ID, fundingCycleData, 0),
+    ).to.be.revertedWith('0x15: BAD_DURATION');
+  });
+
+  it('Should fail if discount rate is above 100%', async function () {
+    const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore } = await setup();
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);
+
+    const fundingCycleData = createFundingCycleData({
+      discountRate: 1000000002,
+      ballot: mockBallot.address,
+    });
+
+    await expect(
+      jbFundingCycleStore.connect(controller).configureFor(PROJECT_ID, fundingCycleData, 0),
+    ).to.be.revertedWith('0x16: BAD_DISCOUNT_RATE');
+  });
+
+  it('Should fail for weight larger than uint88_max', async function () {
+    const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore } = await setup();
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);
+
+    const badWeight = BigNumber.from('1').shl(88);
+
+    const fundingCycleData = createFundingCycleData({
+      weight: badWeight,
+      ballot: mockBallot.address,
+    });
+
+    await expect(
+      jbFundingCycleStore.connect(controller).configureFor(PROJECT_ID, fundingCycleData, 0),
+    ).to.be.revertedWith('0x18: BAD_WEIGHT');
+  });
+});

--- a/test/jb_funding_cycle_store/utils.js
+++ b/test/jb_funding_cycle_store/utils.js
@@ -1,0 +1,13 @@
+export function createFundingCycleData({
+  duration = 604800, // 1 week
+  weight = 0,
+  discountRate = 100000000,
+  ballot,
+}) {
+  return {
+    duration,
+    weight,
+    discountRate,
+    ballot,
+  };
+}


### PR DESCRIPTION
- Updates vscode linter settings as per the conventions set in this pr https://github.com/jbx-protocol/juice-interface/pull/215
- Updates properties of `JBFundingCycleData` struct to match documentation of [JBController::launchProjectFor(...)](https://github.com/jbx-protocol/juice-contracts-v2/blob/main/contracts/JBController.sol#L248)
- Adds a few simple negative tests for `JBFundingCycleStore::configureFor(...)`

