### PR TITLE
Fix:remove unneeded mock initialisation (in JBSplitsStore and JBDirectory tests) (nit)

### DIFF
--- a/deploy/deploy.js
+++ b/deploy/deploy.js
@@ -1,4 +1,4 @@
-const { ethers } = require("hardhat");
+const { ethers } = require('hardhat');
 
 /**
  * Deploys the Juice V2 contracts.
@@ -89,9 +89,9 @@ module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
   });
 
   // Add the deployed JBController as a known controller.
-  const [signer, ..._] = await ethers.getSigners()
+  const [signer, ..._] = await ethers.getSigners();
   const jbDirectoryContract = new ethers.Contract(JBDirectory.address, JBDirectory.abi);
-  await jbDirectoryContract.connect(signer).addToSetControllerAllowlist(JBController.address)
+  await jbDirectoryContract.connect(signer).addToSetControllerAllowlist(JBController.address);
 
   const JBETHPaymentTerminalStore = await deploy('JBETHPaymentTerminalStore', {
     from: deployer,

--- a/test/jb_directory/add_set_controller_allowed_list.test.js
+++ b/test/jb_directory/add_set_controller_allowed_list.test.js
@@ -8,7 +8,6 @@ import jbOperatoreStore from '../../artifacts/contracts/JBOperatorStore.sol/JBOp
 import jbProjects from '../../artifacts/contracts/JBProjects.sol/JBProjects.json';
 
 describe('JBDirectory::addToSetControllerAllowlist(...)', function () {
-
   async function setup() {
     let [deployer, ...addrs] = await ethers.getSigners();
 
@@ -26,7 +25,7 @@ describe('JBDirectory::addToSetControllerAllowlist(...)', function () {
       deployer,
       addrs,
       jbDirectory,
-      mockJbController
+      mockJbController,
     };
   }
 
@@ -34,31 +33,29 @@ describe('JBDirectory::addToSetControllerAllowlist(...)', function () {
     const { deployer, jbDirectory, mockJbController } = await setup();
 
     await expect(
-      jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address)
-    ).to.emit(jbDirectory, 'AddToSetControllerAllowlist')
+      jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address),
+    )
+      .to.emit(jbDirectory, 'AddToSetControllerAllowlist')
       .withArgs(mockJbController.address, deployer.address);
 
-    expect(
-      await jbDirectory.isAllowedToSetController(mockJbController.address)
-    ).to.be.true;
+    expect(await jbDirectory.isAllowedToSetController(mockJbController.address)).to.be.true;
   });
 
-  it('Can\'t add known controller if caller is not JBDirectory owner', async function () {
+  it("Can't add known controller if caller is not JBDirectory owner", async function () {
     const { addrs, jbDirectory, mockJbController } = await setup();
 
     await expect(
-      jbDirectory.connect(addrs[0]).addToSetControllerAllowlist(mockJbController.address)
+      jbDirectory.connect(addrs[0]).addToSetControllerAllowlist(mockJbController.address),
     ).to.revertedWith('Ownable: caller is not the owner');
   });
 
-  it('Can\'t add the same known controller twice', async function () {
+  it("Can't add the same known controller twice", async function () {
     const { deployer, jbDirectory, mockJbController } = await setup();
 
-    await jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address)
+    await jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address);
 
     await expect(
-      jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address)
+      jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address),
     ).to.revertedWith('0x30: ALREADY_ADDED');
   });
-
 });

--- a/test/jb_directory/add_terminals_of.test.js
+++ b/test/jb_directory/add_terminals_of.test.js
@@ -115,7 +115,7 @@ describe('JBDirectory::addTerminalsOf(...)', function () {
       .be.reverted;
   });
 
-  it('Can\'t add if caller does not have permission', async function () {
+  it("Can't add if caller does not have permission", async function () {
     const { addrs, projectOwner, jbDirectory, mockJbProjects, mockJbOperatorStore, terminal1 } =
       await setup();
     const caller = addrs[1];
@@ -130,7 +130,7 @@ describe('JBDirectory::addTerminalsOf(...)', function () {
       .reverted;
   });
 
-  it('Can\'t add terminals with address(0)', async function () {
+  it("Can't add terminals with address(0)", async function () {
     const { projectOwner, jbDirectory, terminal1, terminal2 } = await setup();
 
     let terminals = [terminal1.address, ethers.constants.AddressZero, terminal2.address];
@@ -140,7 +140,7 @@ describe('JBDirectory::addTerminalsOf(...)', function () {
     ).to.be.revertedWith('0x2d: ZERO_ADDRESS');
   });
 
-  it('Can\'t add terminals more than once', async function () {
+  it("Can't add terminals more than once", async function () {
     const { projectOwner, jbDirectory, terminal1, terminal2 } = await setup();
 
     await jbDirectory

--- a/test/jb_directory/is_terminal_delegate_of.test.js
+++ b/test/jb_directory/is_terminal_delegate_of.test.js
@@ -41,14 +41,6 @@ describe('JBDirectory::isTerminalDelegateOf(...)', function () {
     await terminal2.mock.delegate.returns(terminal2Delegate);
 
     await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        ADD_TERMINALS_PERMISSION_INDEX,
-      )
-      .returns(true);
 
     // Add a few terminals
     await jbDirectory

--- a/test/jb_directory/primary_terminal_of.test.js
+++ b/test/jb_directory/primary_terminal_of.test.js
@@ -37,22 +37,6 @@ describe('JBDirectory::primaryTerminalOf(...)', function () {
     let terminal2 = await deployMockContract(projectOwner, jbTerminal.abi);
 
     await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        ADD_TERMINALS_PERMISSION_INDEX,
-      )
-      .returns(true);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        SET_PRIMARY_TERMINAL_PERMISSION_INDEX,
-      )
-      .returns(true);
 
     // Add a few terminals
     await jbDirectory

--- a/test/jb_directory/remove_set_controller_allowed_list.test.js.test.js
+++ b/test/jb_directory/remove_set_controller_allowed_list.test.js.test.js
@@ -25,7 +25,7 @@ describe('JBDirectory::removeFromSetControllerAllowlist(...)', function () {
       deployer,
       addrs,
       jbDirectory,
-      mockJbController
+      mockJbController,
     };
   }
 
@@ -34,26 +34,26 @@ describe('JBDirectory::removeFromSetControllerAllowlist(...)', function () {
     await jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address);
 
     await expect(
-      jbDirectory.connect(deployer).removeFromSetControllerAllowlist(mockJbController.address)
-    ).to.emit(jbDirectory, 'RemoveFromSetControllerAllowlist')
+      jbDirectory.connect(deployer).removeFromSetControllerAllowlist(mockJbController.address),
+    )
+      .to.emit(jbDirectory, 'RemoveFromSetControllerAllowlist')
       .withArgs(mockJbController.address, deployer.address);
   });
 
-  it('Can\'t remove known controller if caller is not JBDirectory owner', async function () {
+  it("Can't remove known controller if caller is not JBDirectory owner", async function () {
     const { deployer, addrs, jbDirectory, mockJbController } = await setup();
     await jbDirectory.connect(deployer).addToSetControllerAllowlist(mockJbController.address);
 
     await expect(
-      jbDirectory.connect(addrs[0]).removeFromSetControllerAllowlist(mockJbController.address)
+      jbDirectory.connect(addrs[0]).removeFromSetControllerAllowlist(mockJbController.address),
     ).to.revertedWith('Ownable: caller is not the owner');
   });
 
-  it('Can\'t remove a controller not in the known controller list', async function () {
+  it("Can't remove a controller not in the known controller list", async function () {
     const { deployer, jbDirectory, mockJbController } = await setup();
 
     await expect(
-      jbDirectory.connect(deployer).removeFromSetControllerAllowlist(mockJbController.address)
+      jbDirectory.connect(deployer).removeFromSetControllerAllowlist(mockJbController.address),
     ).to.revertedWith('0x31: NOT_FOUND');
   });
-
 });

--- a/test/jb_directory/remove_terminal_of.test.js
+++ b/test/jb_directory/remove_terminal_of.test.js
@@ -83,7 +83,7 @@ describe('JBDirectory::removeTerminalOf(...)', function () {
     expect(terminals).to.eql([terminal2.address]);
   });
 
-  it('Can\'t remove terminal if caller is not project owner but has permissions', async function () {
+  it("Can't remove terminal if caller is not project owner but has permissions", async function () {
     const { projectOwner, addrs, jbDirectory, mockJbOperatorStore, terminal1 } = await setup();
     let caller = addrs[1];
 

--- a/test/jb_directory/remove_terminal_of.test.js
+++ b/test/jb_directory/remove_terminal_of.test.js
@@ -42,14 +42,6 @@ describe('JBDirectory::removeTerminalOf(...)', function () {
         projectOwner.address,
         projectOwner.address,
         PROJECT_ID,
-        ADD_TERMINALS_PERMISSION_INDEX,
-      )
-      .returns(true);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
         REMOVE_TERMINAL_PERMISSION_INDEX,
       )
       .returns(true);

--- a/test/jb_directory/set_controller_of.test.js
+++ b/test/jb_directory/set_controller_of.test.js
@@ -72,11 +72,8 @@ describe('JBDirectory::setControllerOf(...)', function () {
 
     await mockJbProjects.mock.count.returns(PROJECT_ID);
 
-    await expect(
-      jbDirectory
-        .connect(projectOwner)
-        .setControllerOf(PROJECT_ID, controller1.address)
-    ).to.not.be.reverted;
+    await expect(jbDirectory.connect(projectOwner).setControllerOf(PROJECT_ID, controller1.address))
+      .to.not.be.reverted;
 
     let controller = await jbDirectory.connect(projectOwner).controllerOf(PROJECT_ID);
     expect(controller).to.equal(controller1.address);
@@ -115,13 +112,14 @@ describe('JBDirectory::setControllerOf(...)', function () {
   });
 
   it('Should set controller if both caller and new controller are in setControllerAllowlist', async function () {
-    const { deployer,
+    const {
+      deployer,
       projectOwner,
       jbDirectory,
       mockJbProjects,
       mockJbOperatorStore,
       controller1,
-      controller2
+      controller2,
     } = await setup();
 
     let caller = await impersonateAccount(controller1.address);
@@ -137,16 +135,23 @@ describe('JBDirectory::setControllerOf(...)', function () {
       .returns(false);
 
     // Add caller and new controller to SetControllerAllowlist
-    await jbDirectory.connect(deployer).addToSetControllerAllowlist(caller.address)
-    await jbDirectory.connect(deployer).addToSetControllerAllowlist(controller2.address)
+    await jbDirectory.connect(deployer).addToSetControllerAllowlist(caller.address);
+    await jbDirectory.connect(deployer).addToSetControllerAllowlist(controller2.address);
 
     await expect(jbDirectory.connect(caller).setControllerOf(PROJECT_ID, controller2.address)).to
       .not.be.reverted;
   });
 
-  it('Can\'t set if new controller is in setControllerAllowlist but caller is not and is not authorized', async function () {
-    const { deployer, projectOwner, jbDirectory, mockJbProjects, mockJbOperatorStore, controller1, controller2 } =
-      await setup();
+  it("Can't set if new controller is in setControllerAllowlist but caller is not and is not authorized", async function () {
+    const {
+      deployer,
+      projectOwner,
+      jbDirectory,
+      mockJbProjects,
+      mockJbOperatorStore,
+      controller1,
+      controller2,
+    } = await setup();
 
     let caller = await impersonateAccount(controller1.address);
 
@@ -160,15 +165,23 @@ describe('JBDirectory::setControllerOf(...)', function () {
       .returns(false);
 
     // Add the new controller but not caller to SetControllerAllowlist
-    await jbDirectory.connect(deployer).addToSetControllerAllowlist(controller2.address)
+    await jbDirectory.connect(deployer).addToSetControllerAllowlist(controller2.address);
 
-    await expect(jbDirectory.connect(caller).setControllerOf(PROJECT_ID, controller2.address)).to.be
-      .revertedWith('Operatable: UNAUTHORIZED');
+    await expect(
+      jbDirectory.connect(caller).setControllerOf(PROJECT_ID, controller2.address),
+    ).to.be.revertedWith('Operatable: UNAUTHORIZED');
   });
 
-  it('Can\'t set if caller is in setControllerAllowlist but new controller is not', async function () {
-    const { deployer, projectOwner, jbDirectory, mockJbProjects, mockJbOperatorStore, controller1, controller2 } =
-      await setup();
+  it("Can't set if caller is in setControllerAllowlist but new controller is not", async function () {
+    const {
+      deployer,
+      projectOwner,
+      jbDirectory,
+      mockJbProjects,
+      mockJbOperatorStore,
+      controller1,
+      controller2,
+    } = await setup();
 
     let caller = await impersonateAccount(controller1.address);
 
@@ -184,7 +197,8 @@ describe('JBDirectory::setControllerOf(...)', function () {
     // Add caller but not the new controller to SetControllerAllowlist
     await jbDirectory.connect(deployer).addToSetControllerAllowlist(caller.address);
 
-    await expect(jbDirectory.connect(caller).setControllerOf(PROJECT_ID, controller2.address)).to.be
-      .revertedWith('Operatable: UNAUTHORIZED');
+    await expect(
+      jbDirectory.connect(caller).setControllerOf(PROJECT_ID, controller2.address),
+    ).to.be.revertedWith('Operatable: UNAUTHORIZED');
   });
 });

--- a/test/jb_directory/set_controller_of.test.js
+++ b/test/jb_directory/set_controller_of.test.js
@@ -36,14 +36,6 @@ describe('JBDirectory::setControllerOf(...)', function () {
     let controller2 = await deployMockContract(projectOwner, jbController.abi);
 
     await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        SET_CONTROLLER_PERMISSION_INDEX,
-      )
-      .returns(true);
 
     return {
       projectOwner,

--- a/test/jb_directory/set_primary_terminal_of.test.js
+++ b/test/jb_directory/set_primary_terminal_of.test.js
@@ -85,7 +85,7 @@ describe('JBDirectory::setPrimaryTerminalOf(...)', function () {
     expect(resultTerminals).to.eql(expectedTerminals);
   });
 
-  it('Can\'t set primary terminal if caller is not project owner but has permissions', async function () {
+  it("Can't set primary terminal if caller is not project owner but has permissions", async function () {
     const { projectOwner, addrs, jbDirectory, mockJbOperatorStore, terminal1 } = await setup();
     let caller = addrs[1];
 

--- a/test/jb_directory/set_primary_terminal_of.test.js
+++ b/test/jb_directory/set_primary_terminal_of.test.js
@@ -36,14 +36,6 @@ describe('JBDirectory::setPrimaryTerminalOf(...)', function () {
     let terminal2 = await deployMockContract(projectOwner, jbTerminal.abi);
 
     await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        ADD_TERMINALS_PERMISSION_INDEX,
-      )
-      .returns(true);
 
     return {
       projectOwner,

--- a/test/jb_directory/terminals_of.test.js
+++ b/test/jb_directory/terminals_of.test.js
@@ -35,14 +35,6 @@ describe('JBDirectory::terminalsOf(...)', function () {
     let terminal2 = await deployMockContract(projectOwner, jbTerminal.abi);
 
     await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(
-        projectOwner.address,
-        projectOwner.address,
-        PROJECT_ID,
-        ADD_TERMINALS_PERMISSION_INDEX,
-      )
-      .returns(true);
 
     // Add a few terminals
     await jbDirectory

--- a/test/jb_operator_store/has_permission.test.js
+++ b/test/jb_operator_store/has_permission.test.js
@@ -44,7 +44,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     for (let permissionIndex of PERMISSION_INDEXES_1) {
@@ -55,7 +55,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
             /*operator=*/ projectOwner.address,
             /*account=*/ deployer.address,
             /*domain=*/ DOMAIN,
-            /*permissionIndex=*/ permissionIndex
+            /*permissionIndex=*/ permissionIndex,
           ),
       ).to.be.true;
     }
@@ -69,7 +69,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
       .setOperator([
         /*operator=*/ addrs[1].address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     for (let permissionIndex of PERMISSION_INDEXES_1) {
@@ -80,7 +80,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
             /*operator=*/ addrs[1].address,
             /*account=*/ deployer.address,
             /*domain=*/ DOMAIN,
-            /*permissionIndex=*/ permissionIndex
+            /*permissionIndex=*/ permissionIndex,
           ),
       ).to.be.true;
     }
@@ -108,7 +108,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     for (let permissionIndex of PERMISSION_INDEXES_2) {
@@ -119,7 +119,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
             /*operator=*/ projectOwner.address,
             /*account=*/ deployer.address,
             /*domain=*/ DOMAIN,
-            /*permissionIndex=*/ permissionIndex
+            /*permissionIndex=*/ permissionIndex,
           ),
       ).to.be.false;
     }
@@ -133,7 +133,7 @@ describe('JBOperatorStore::hasPermission(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndex=*/ PERMISSION_INDEXES_1
+        /*permissionIndex=*/ PERMISSION_INDEXES_1,
       ]);
 
     for (let permissionIndex of PERMISSION_INDEXES_1) {

--- a/test/jb_operator_store/has_permissions.test.js
+++ b/test/jb_operator_store/has_permissions.test.js
@@ -43,7 +43,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     expect(
@@ -53,7 +53,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
           /*operator=*/ projectOwner.address,
           /*account=*/ deployer.address,
           /*domain=*/ DOMAIN,
-          /*permissionIndexes=*/ PERMISSION_INDEXES_1
+          /*permissionIndexes=*/ PERMISSION_INDEXES_1,
         ),
     ).to.be.true;
   });
@@ -66,7 +66,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
       .setOperator([
         /*operator=*/ addrs[0].address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     expect(
@@ -76,7 +76,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
           /*operator=*/ addrs[0].address,
           /*account=*/ deployer.address,
           /*domain=*/ DOMAIN,
-          /*permissionIndexes=*/ PERMISSION_INDEXES_1
+          /*permissionIndexes=*/ PERMISSION_INDEXES_1,
         ),
     ).to.be.true;
   });
@@ -103,7 +103,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     expect(
@@ -113,7 +113,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
           /*operator=*/ projectOwner.address,
           /*account=*/ deployer.address,
           /*domain=*/ DOMAIN,
-          /*permissionIndexes=*/ PERMISSION_INDEXES_2
+          /*permissionIndexes=*/ PERMISSION_INDEXES_2,
         ),
     ).to.be.false;
   });
@@ -126,7 +126,7 @@ describe('JBOperatorStore::hasPermissions(...)', function () {
       .setOperator([
         /*operator=*/ projectOwner.address,
         /*domain=*/ DOMAIN,
-        /*permissionIndexes=*/ PERMISSION_INDEXES_1
+        /*permissionIndexes=*/ PERMISSION_INDEXES_1,
       ]);
 
     expect(

--- a/test/jb_operator_store/set_operator.test.js
+++ b/test/jb_operator_store/set_operator.test.js
@@ -37,7 +37,7 @@ describe('JBOperatorStore::setOperator(...)', function () {
       .setOperator([
         /*operator=*/ operator.address,
         /*domain=*/ domain,
-        /*permissionsIndexes=*/ permissionIndexes
+        /*permissionsIndexes=*/ permissionIndexes,
       ]);
 
     await expect(tx)
@@ -50,12 +50,9 @@ describe('JBOperatorStore::setOperator(...)', function () {
         packedPermissionIndexes,
       );
 
-    expect(await jbOperatorStore
-      .permissionsOf(
-        operator.address,
-        account.address,
-        domain))
-      .to.equal(packedPermissionIndexes);
+    expect(await jbOperatorStore.permissionsOf(operator.address, account.address, domain)).to.equal(
+      packedPermissionIndexes,
+    );
   }
 
   it('Set operator with no previous value, override it, and clear it', async function () {
@@ -98,7 +95,7 @@ describe('JBOperatorStore::setOperator(...)', function () {
         .setOperator([
           /*operator=*/ projectOwner.address,
           /*domain=*/ DOMAIN,
-          /*permissionsIndexes=*/ PERMISSION_INDEXES_OUT_OF_BOUND
+          /*permissionsIndexes=*/ PERMISSION_INDEXES_OUT_OF_BOUND,
         ]),
     ).to.be.revertedWith('0x02: INDEX_OUT_OF_BOUNDS');
   });

--- a/test/jb_projects/renew_handle_of.test.js
+++ b/test/jb_projects/renew_handle_of.test.js
@@ -17,7 +17,7 @@ describe('JBProjects::renewHandle(...)', function () {
     let jbOperations = await jbOperationsFactory.deploy();
 
     RENEW_HANDLE_PERMISSION_INDEX = await jbOperations.RENEW_HANDLE();
-  })
+  });
 
   async function setup() {
     let [deployer, projectOwner, ...addrs] = await ethers.getSigners();
@@ -58,7 +58,11 @@ describe('JBProjects::renewHandle(...)', function () {
 
     await expect(tx)
       .to.emit(jbProjectsStore, 'RenewHandle')
-      .withArgs(ethers.utils.formatBytes32String(PROJECT_HANDLE), PROJECT_ID_1, projectOwner.address);
+      .withArgs(
+        ethers.utils.formatBytes32String(PROJECT_HANDLE),
+        PROJECT_ID_1,
+        projectOwner.address,
+      );
   });
 
   it(`Can't renew handle of project from non owner`, async function () {
@@ -66,11 +70,7 @@ describe('JBProjects::renewHandle(...)', function () {
 
     await jbProjectsStore
       .connect(deployer)
-      .createFor(
-        deployer.address,
-        ethers.utils.formatBytes32String(PROJECT_HANDLE),
-        METADATA_CID,
-      );
+      .createFor(deployer.address, ethers.utils.formatBytes32String(PROJECT_HANDLE), METADATA_CID);
 
     await expect(
       jbProjectsStore.connect(projectOwner).renewHandleOf(PROJECT_ID_1),
@@ -88,9 +88,9 @@ describe('JBProjects::renewHandle(...)', function () {
         METADATA_CID,
       );
 
-    await expect(
-      jbProjectsStore.connect(deployer).renewHandleOf(PROJECT_ID_1),
-    ).to.be.revertedWith('Operatable: UNAUTHORIZED');
+    await expect(jbProjectsStore.connect(deployer).renewHandleOf(PROJECT_ID_1)).to.be.revertedWith(
+      'Operatable: UNAUTHORIZED',
+    );
   });
 
   it(`Can't renew handle of non owner with no permissions`, async function () {
@@ -104,9 +104,9 @@ describe('JBProjects::renewHandle(...)', function () {
         METADATA_CID,
       );
 
-    await expect(
-      jbProjectsStore.connect(addrs[0]).renewHandleOf(PROJECT_ID_1),
-    ).to.be.revertedWith('Operatable: UNAUTHORIZED');
+    await expect(jbProjectsStore.connect(addrs[0]).renewHandleOf(PROJECT_ID_1)).to.be.revertedWith(
+      'Operatable: UNAUTHORIZED',
+    );
   });
 
   it(`Can't renew handle of non owner even with permissions`, async function () {
@@ -124,8 +124,8 @@ describe('JBProjects::renewHandle(...)', function () {
       .withArgs(addrs[0].address, deployer.address, PROJECT_ID_1, RENEW_HANDLE_PERMISSION_INDEX)
       .returns(true);
 
-    await expect(
-      jbProjectsStore.connect(addrs[0]).renewHandleOf(PROJECT_ID_1),
-    ).to.be.revertedWith('Operatable: UNAUTHORIZED');
+    await expect(jbProjectsStore.connect(addrs[0]).renewHandleOf(PROJECT_ID_1)).to.be.revertedWith(
+      'Operatable: UNAUTHORIZED',
+    );
   });
 });

--- a/test/jb_projects/set_handle_of.test.js
+++ b/test/jb_projects/set_handle_of.test.js
@@ -19,7 +19,7 @@ describe('JBProjects::setHandleOf(...)', function () {
     let jbOperations = await jbOperationsFactory.deploy();
 
     SET_HANDLE_PERMISSION_INDEX = await jbOperations.SET_HANDLE();
-  })
+  });
 
   async function setup() {
     let [deployer, projectOwner, ...addrs] = await ethers.getSigners();
@@ -53,10 +53,7 @@ describe('JBProjects::setHandleOf(...)', function () {
 
     let tx = await jbProjectsStore
       .connect(projectOwner)
-      .setHandleOf(
-        PROJECT_ID_1,
-        ethers.utils.formatBytes32String(PROJECT_HANDLE_NOT_TAKEN),
-      );
+      .setHandleOf(PROJECT_ID_1, ethers.utils.formatBytes32String(PROJECT_HANDLE_NOT_TAKEN));
 
     let storedHandle = await jbProjectsStore.connect(deployer).handleOf(1);
     let storedProjectId = await jbProjectsStore
@@ -89,10 +86,7 @@ describe('JBProjects::setHandleOf(...)', function () {
     await expect(
       jbProjectsStore
         .connect(projectOwner)
-        .setHandleOf(
-          PROJECT_ID_1,
-          ethers.utils.formatBytes32String(PROJECT_HANDLE_EMPTY),
-        ),
+        .setHandleOf(PROJECT_ID_1, ethers.utils.formatBytes32String(PROJECT_HANDLE_EMPTY)),
     ).to.be.revertedWith('0x08: EMPTY_HANDLE');
   });
 
@@ -110,10 +104,7 @@ describe('JBProjects::setHandleOf(...)', function () {
     await expect(
       jbProjectsStore
         .connect(projectOwner)
-        .setHandleOf(
-          PROJECT_ID_1,
-          ethers.utils.formatBytes32String(PROJECT_HANDLE),
-        ),
+        .setHandleOf(PROJECT_ID_1, ethers.utils.formatBytes32String(PROJECT_HANDLE)),
     ).to.be.revertedWith('0x09: HANDLE_TAKEN');
   });
 
@@ -131,10 +122,7 @@ describe('JBProjects::setHandleOf(...)', function () {
     await expect(
       jbProjectsStore
         .connect(addrs[0])
-        .setHandleOf(
-          PROJECT_ID_1,
-          ethers.utils.formatBytes32String(PROJECT_HANDLE),
-        ),
+        .setHandleOf(PROJECT_ID_1, ethers.utils.formatBytes32String(PROJECT_HANDLE)),
     ).to.be.reverted;
   });
 
@@ -156,10 +144,7 @@ describe('JBProjects::setHandleOf(...)', function () {
     await expect(
       jbProjectsStore
         .connect(addrs[0])
-        .setHandleOf(
-          PROJECT_ID_1,
-          ethers.utils.formatBytes32String(PROJECT_HANDLE),
-        ),
+        .setHandleOf(PROJECT_ID_1, ethers.utils.formatBytes32String(PROJECT_HANDLE)),
     ).to.be.reverted;
   });
 });

--- a/test/jb_projects/set_metadatacid_of.test.js
+++ b/test/jb_projects/set_metadatacid_of.test.js
@@ -62,7 +62,7 @@ describe('JBProjects::setMetadataCidOf(...)', function () {
       .withArgs(PROJECT_ID_1, METADATA_CID_2, projectOwner.address);
   });
 
-  it(`Can set MetadataCid on project if caller is not owner but has permission`, async function () {
+  it(`Should set MetadataCid on project if caller is not owner but has permission`, async function () {
     const { projectOwner, deployer, addrs, jbProjectsStore, mockJbOperatorStore } = await setup();
 
     await jbProjectsStore

--- a/test/jb_projects/set_metadatacid_of.test.js
+++ b/test/jb_projects/set_metadatacid_of.test.js
@@ -49,10 +49,7 @@ describe('JBProjects::setMetadataCidOf(...)', function () {
 
     let tx = await jbProjectsStore
       .connect(projectOwner)
-      .setMetadataCidOf(
-        PROJECT_ID_1,
-        METADATA_CID_2
-      );
+      .setMetadataCidOf(PROJECT_ID_1, METADATA_CID_2);
 
     let storedMetadataCid = await jbProjectsStore.connect(deployer).metadataCidOf(PROJECT_ID_1);
     await expect(storedMetadataCid).to.equal(METADATA_CID_2);
@@ -82,14 +79,8 @@ describe('JBProjects::setMetadataCidOf(...)', function () {
       )
       .returns(true);
 
-    await expect(
-      jbProjectsStore
-        .connect(addrs[1])
-        .setMetadataCidOf(
-          PROJECT_ID_1,
-          METADATA_CID_2
-        ),
-    ).to.not.be.reverted;
+    await expect(jbProjectsStore.connect(addrs[1]).setMetadataCidOf(PROJECT_ID_1, METADATA_CID_2))
+      .to.not.be.reverted;
   });
 
   it(`Can't set MetadataCid on project if caller is not owner and doesn't have permission`, async function () {
@@ -112,13 +103,7 @@ describe('JBProjects::setMetadataCidOf(...)', function () {
       )
       .returns(false);
 
-    await expect(
-      jbProjectsStore
-        .connect(addrs[1])
-        .setMetadataCidOf(
-          PROJECT_ID_1,
-          METADATA_CID_2
-        ),
-    ).to.be.reverted;
+    await expect(jbProjectsStore.connect(addrs[1]).setMetadataCidOf(PROJECT_ID_1, METADATA_CID_2))
+      .to.be.reverted;
   });
 });

--- a/test/jb_splits_store/set.test.js
+++ b/test/jb_splits_store/set.test.js
@@ -25,28 +25,33 @@ describe('JBSplitsStore::set(...)', function () {
     let mockJbProjects = await deployMockContract(deployer, jbProjects.abi);
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
 
-    await mockJbProjects.mock.ownerOf
-      .withArgs(PROJECT_ID)
-      .returns(projectOwner.address);
+    await mockJbProjects.mock.ownerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
 
-    await mockJbDirectory.mock.controllerOf
-      .withArgs(PROJECT_ID)
-      .returns(projectOwner.address);
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(projectOwner.address);
 
     let jbSplitsStoreFact = await ethers.getContractFactory('JBSplitsStore');
     let jbSplitsStore = await jbSplitsStoreFact.deploy(
       mockJbOperatorStore.address,
       mockJbProjects.address,
-      mockJbDirectory.address
+      mockJbDirectory.address,
     );
 
     let splits = makeSplits(addrs[0].address);
 
-    return { deployer, projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbProjects, mockJbDirectory };
+    return {
+      deployer,
+      projectOwner,
+      addrs,
+      jbSplitsStore,
+      splits,
+      mockJbOperatorStore,
+      mockJbProjects,
+      mockJbDirectory,
+    };
   }
 
-  function makeSplits(beneficiaryAddress, count=4) {
-    let splits = []
+  function makeSplits(beneficiaryAddress, count = 4) {
+    let splits = [];
     for (let i = 0; i < count; i++) {
       splits.push({
         preferClaimed: false,
@@ -54,14 +59,14 @@ describe('JBSplitsStore::set(...)', function () {
         lockedUntil: 0,
         beneficiary: beneficiaryAddress,
         allocator: ethers.constants.AddressZero,
-        projectId: 0
+        projectId: 0,
       });
     }
     return splits;
   }
 
   function cleanSplits(splits) {
-    let cleanedSplits = []
+    let cleanedSplits = [];
     for (let split of splits) {
       cleanedSplits.push({
         preferClaimed: split[0],
@@ -69,24 +74,20 @@ describe('JBSplitsStore::set(...)', function () {
         lockedUntil: split[2],
         beneficiary: split[3],
         allocator: split[4],
-        projectId: split[5].toNumber()
-      })
+        projectId: split[5].toNumber(),
+      });
     }
     return cleanedSplits;
   }
 
   it('Should set splits with beneficiaries and emit events if project owner', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } = await setup();
+    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } =
+      await setup();
 
     await mockJbOperatorStore.mock.hasPermission.returns(false);
     await mockJbDirectory.mock.controllerOf.returns(addrs[0].address);
 
-    const tx = await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    );
+    const tx = await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits);
 
     // Expect one event per split
     await Promise.all(
@@ -99,10 +100,11 @@ describe('JBSplitsStore::set(...)', function () {
 
     let splitsStored = cleanSplits(await jbSplitsStore.splitsOf(PROJECT_ID, DOMAIN, GROUP));
     expect(splitsStored).to.eql(splits);
-  })
+  });
 
   it('Should set splits with allocators set', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } = await setup();
+    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } =
+      await setup();
 
     await mockJbOperatorStore.mock.hasPermission.returns(false);
     await mockJbDirectory.mock.controllerOf.returns(addrs[0].address);
@@ -113,19 +115,15 @@ describe('JBSplitsStore::set(...)', function () {
       allocator: addrs[5].address,
     }));
 
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      newSplits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, newSplits);
 
     let splitsStored = cleanSplits(await jbSplitsStore.splitsOf(PROJECT_ID, DOMAIN, GROUP));
     expect(splitsStored).to.eql(newSplits);
-  })
+  });
 
   it('Should set splits with allocators and beneficiaries set', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } = await setup();
+    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbDirectory } =
+      await setup();
 
     await mockJbOperatorStore.mock.hasPermission.returns(false);
     await mockJbDirectory.mock.controllerOf.returns(addrs[0].address);
@@ -136,66 +134,41 @@ describe('JBSplitsStore::set(...)', function () {
       allocator: addrs[5].address,
     }));
 
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      newSplits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, newSplits);
 
     let splitsStored = cleanSplits(await jbSplitsStore.splitsOf(PROJECT_ID, DOMAIN, GROUP));
     expect(splitsStored).to.eql(newSplits);
-  })
+  });
 
   it('Should set new splits when overwriting existing splits with the same ID/Domain/Group', async function () {
     const { projectOwner, addrs, jbSplitsStore, splits } = await setup();
 
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits);
 
     let newBeneficiary = addrs[5].address;
     let newSplits = makeSplits(newBeneficiary);
 
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      newSplits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, newSplits);
 
     let splitsStored = cleanSplits(await jbSplitsStore.splitsOf(PROJECT_ID, DOMAIN, GROUP));
     expect(splitsStored).to.eql(newSplits);
-  })
+  });
 
-  it('Can\'t set new splits without including a preexisting locked one', async function () {
+  it("Can't set new splits without including a preexisting locked one", async function () {
     const { projectOwner, addrs, jbSplitsStore, splits } = await setup();
 
     // Set one locked split
     splits[1].lockedUntil = await daysFromNow(1);
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits);
 
     // New splits without the previous locked one
     let newBeneficiary = addrs[5].address;
     let newSplits = makeSplits(newBeneficiary);
 
     await expect(
-      jbSplitsStore.connect(projectOwner).set(
-        PROJECT_ID,
-        DOMAIN,
-        GROUP,
-        newSplits
-      )
+      jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, newSplits),
     ).to.be.revertedWith('0x0f: SOME_LOCKED');
-  })
+  });
 
   it('Should set new splits with extension of a preexisting locked one', async function () {
     const { projectOwner, addrs, jbSplitsStore, splits } = await setup();
@@ -204,12 +177,7 @@ describe('JBSplitsStore::set(...)', function () {
 
     // Set one locked split
     splits[1].lockedUntil = lockDate;
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits);
 
     // Try to set new ones, with lock extension of one day
     let newLockDate = daysFromDate(lockDate, 1);
@@ -218,81 +186,74 @@ describe('JBSplitsStore::set(...)', function () {
     newSplits[1].lockedUntil = newLockDate;
     newSplits[1].beneficiary = addrs[0].address;
 
-    await jbSplitsStore.connect(projectOwner).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      newSplits
-    );
+    await jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, newSplits);
 
     let splitsStored = await jbSplitsStore.splitsOf(PROJECT_ID, DOMAIN, GROUP);
     expect(splitsStored[1].lockedUntil).to.equal(newLockDate);
-  })
+  });
 
-  it('Can\'t set splits when a split has a percent of 0', async function () {
+  it("Can't set splits when a split has a percent of 0", async function () {
     const { projectOwner, jbSplitsStore, splits } = await setup();
 
     // Set one 0% split
     splits[1].percent = 0;
 
     await expect(
-      jbSplitsStore.connect(projectOwner).set(
-        PROJECT_ID,
-        DOMAIN,
-        GROUP,
-        splits)
+      jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits),
     ).to.be.revertedWith('0x10: BAD_SPLIT_PERCENT');
-  })
+  });
 
-  it('Can\'t set splits when a split has both allocator and beneficiary zero address', async function () {
+  it("Can't set splits when a split has both allocator and beneficiary zero address", async function () {
     const { projectOwner, jbSplitsStore, splits } = await setup();
 
     splits[1].beneficiary = ethers.constants.AddressZero;
     splits[1].allocator = ethers.constants.AddressZero;
 
     await expect(
-      jbSplitsStore.connect(projectOwner).set(
-        PROJECT_ID,
-        DOMAIN,
-        GROUP,
-        splits)
+      jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits),
     ).to.be.revertedWith('0x11: ZERO_ADDRESS');
-  })
+  });
 
-  it('Can\'t set splits if the sum of the percents is greather than 10000000', async function () {
+  it("Can't set splits if the sum of the percents is greather than 10000000", async function () {
     const { projectOwner, jbSplitsStore, splits } = await setup();
 
     // Set sum at 10000001
     splits[0].percent += 1;
 
     await expect(
-      jbSplitsStore.connect(projectOwner).set(
-        PROJECT_ID,
-        DOMAIN,
-        GROUP,
-        splits)
+      jbSplitsStore.connect(projectOwner).set(PROJECT_ID, DOMAIN, GROUP, splits),
     ).to.be.revertedWith('0x12: BAD_TOTAL_PERCENT');
-  })
+  });
 
   it('Should set splits if controller', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbProjects, mockJbDirectory } = await setup();
+    const {
+      projectOwner,
+      addrs,
+      jbSplitsStore,
+      splits,
+      mockJbOperatorStore,
+      mockJbProjects,
+      mockJbDirectory,
+    } = await setup();
 
     let caller = addrs[0];
 
-    await mockJbDirectory.mock.controllerOf
-    .withArgs(PROJECT_ID)
-    .returns(caller.address);
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(caller.address);
 
-    await expect(jbSplitsStore.connect(caller).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    )).to.be.not.reverted;
-  })
+    await expect(jbSplitsStore.connect(caller).set(PROJECT_ID, DOMAIN, GROUP, splits)).to.be.not
+      .reverted;
+  });
 
   it('Should set splits if not the project owner but has permission', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbProjects, mockJbDirectory } = await setup();
+    const {
+      projectOwner,
+      addrs,
+      jbSplitsStore,
+      splits,
+      mockJbOperatorStore,
+      mockJbProjects,
+      mockJbDirectory,
+    } = await setup();
 
     let caller = addrs[0];
 
@@ -300,16 +261,20 @@ describe('JBSplitsStore::set(...)', function () {
       .withArgs(caller.address, projectOwner.address, PROJECT_ID, SET_SPLITS_PERMISSION_INDEX)
       .returns(true);
 
-    await expect(jbSplitsStore.connect(caller).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits
-    )).to.be.not.reverted;
-  })
+    await expect(jbSplitsStore.connect(caller).set(PROJECT_ID, DOMAIN, GROUP, splits)).to.be.not
+      .reverted;
+  });
 
-  it('Can\'t set splits if not project owner and doesn\'t have permission', async function () {
-    const { projectOwner, addrs, jbSplitsStore, splits, mockJbOperatorStore, mockJbProjects, mockJbDirectory } = await setup();
+  it("Can't set splits if not project owner and doesn't have permission", async function () {
+    const {
+      projectOwner,
+      addrs,
+      jbSplitsStore,
+      splits,
+      mockJbOperatorStore,
+      mockJbProjects,
+      mockJbDirectory,
+    } = await setup();
 
     let caller = addrs[1];
 
@@ -321,11 +286,8 @@ describe('JBSplitsStore::set(...)', function () {
       .withArgs(caller.address, projectOwner.address, 0, SET_SPLITS_PERMISSION_INDEX)
       .returns(false);
 
-    await expect(jbSplitsStore.connect(caller).set(
-      PROJECT_ID,
-      DOMAIN,
-      GROUP,
-      splits)
+    await expect(
+      jbSplitsStore.connect(caller).set(PROJECT_ID, DOMAIN, GROUP, splits),
     ).to.be.revertedWith('Operatable: UNAUTHORIZED');
-  })
-})
+  });
+});

--- a/test/jb_splits_store/set.test.js
+++ b/test/jb_splits_store/set.test.js
@@ -25,10 +25,6 @@ describe('JBSplitsStore::set(...)', function () {
     let mockJbProjects = await deployMockContract(deployer, jbProjects.abi);
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
 
-    await mockJbOperatorStore.mock.hasPermission
-      .withArgs(projectOwner.address, projectOwner.address, PROJECT_ID, SET_SPLITS_PERMISSION_INDEX)
-      .returns(true);
-
     await mockJbProjects.mock.ownerOf
       .withArgs(PROJECT_ID)
       .returns(projectOwner.address);


### PR DESCRIPTION
With the modifier requirePermission(...) and requirePermissionAllowingOverrides(...) in JBOperatable.sol being https://github.com/jbx-protocol/juice-contracts-v2/blob/40352e4fea2f7bc37b42783dcc3884e497ed9510/contracts/abstract/JBOperatable.sol#L16-L20
having to mock hasPermission.withArgs(projectOwner.address, projectOwner.address(...) returning `true` is useless since `msg.sender==_account` returns true before triggering it