### PR TITLE
Remove one time funding cycles 

### DIFF
--- a/contracts/JBController.sol
+++ b/contracts/JBController.sol
@@ -255,10 +255,9 @@ contract JBController is IJBController, JBTerminalUtility, JBOperatable, Reentra
         A value of 0 means that the weight should be inherited and potentially discounted from the currently active cycle if possible. Otherwise a weight of 0 will be used.
         A value of 1 means that no tokens should be minted regardless of how many ETH was paid. The protocol will set the stored weight value to 0.
         A value of 1 X 10^18 means that one token should be minted per ETH received.
-      @dev _data.discountRate A number from 0-1000000001 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
+      @dev _data.discountRate A number from 0-1000000000 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
         If it's 0, each funding cycle will have equal weight.
         If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
-        If the number is 1000000001, an non-recurring funding cycle will get made.
       @dev _data.ballot The ballot contract that will be used to approve subsequent reconfigurations. Must adhere to the IFundingCycleBallot interface.
     @param _metadata A JBFundingCycleMetadata data structure specifying the controller specific params that a funding cycle can have. These properties will remain fixed for the duration of the funding cycle.
       @dev _metadata.reservedRate A number from 0-10000 (0-100%) indicating the percentage of each contribution's newly minted tokens that will be reserved for the token splits.
@@ -334,10 +333,9 @@ contract JBController is IJBController, JBTerminalUtility, JBOperatable, Reentra
         A value of 0 means that the weight should be inherited and potentially discounted from the currently active cycle if possible. Otherwise a weight of 0 will be used.
         A value of 1 means that no tokens should be minted regardless of how many ETH was paid. The protocol will set the stored weight value to 0.
         A value of 1 X 10^18 means that one token should be minted per ETH received.
-      @dev _data.discountRate A number from 0-1000000001 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
+      @dev _data.discountRate A number from 0-1000000000 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
         If it's 0, each funding cycle will have equal weight.
         If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
-        If the number is 1000000001, an non-recurring funding cycle will get made.
       @dev _data.ballot The ballot contract that will be used to approve subsequent reconfigurations. Must adhere to the IFundingCycleBallot interface.
     @param _metadata A JBFundingCycleMetadata data structure specifying the controller specific params that a funding cycle can have. These properties will remain fixed for the duration of the funding cycle.
       @dev _metadata.reservedRate A number from 0-10000 (0-100%) indicating the percentage of each contribution's newly minted tokens that will be reserved for the token splits.

--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -12,6 +12,16 @@ import './abstract/JBControllerUtility.sol';
 */
 contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
   //*********************************************************************//
+  // ------------------------- private constants ----------------------- //
+  //*********************************************************************//
+
+  /** 
+    @notice
+    A funding cycle's discount rate is expressed as a percentage out of 100000000.
+  */
+  uint256 private constant _MAX_DISCOUNT_RATE = 100000000;
+
+  //*********************************************************************//
   // --------------------- private stored properties ------------------- //
   //*********************************************************************//
 
@@ -250,7 +260,7 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     require(_data.duration <= type(uint64).max && _data.duration > 1000, '0x15: BAD_DURATION');
 
     // Discount rate token must be less than or equal to 100%.
-    require(_data.discountRate <= 100000000, '0x16: BAD_DISCOUNT_RATE');
+    require(_data.discountRate <= _MAX_DISCOUNT_RATE, '0x16: BAD_DISCOUNT_RATE');
 
     // Weight must fit into a uint88.
     require(_data.weight <= type(uint88).max, '0x18: BAD_WEIGHT');
@@ -701,8 +711,8 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
       return
         PRBMath.mulDiv(
           _baseFundingCycle.weight,
-          1000000000 - _baseFundingCycle.discountRate,
-          1000000000
+          _MAX_DISCOUNT_RATE - _baseFundingCycle.discountRate,
+          _MAX_DISCOUNT_RATE
         );
 
     // The weight should be based off the base funding cycle's weight.
@@ -720,7 +730,11 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     for (uint256 i = 0; i < _discountMultiple; i++)
       // The number of times to apply the discount rate.
       // Base the new weight on the specified funding cycle's weight.
-      weight = PRBMath.mulDiv(weight, 1000000000 - _baseFundingCycle.discountRate, 1000000000);
+      weight = PRBMath.mulDiv(
+        weight,
+        _MAX_DISCOUNT_RATE - _baseFundingCycle.discountRate,
+        _MAX_DISCOUNT_RATE
+      );
   }
 
   /** 

--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -107,9 +107,6 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     // There's no queued if the current has a duration of 0.
     if (_fundingCycle.duration == 0) return _getStructFor(0, 0);
 
-    // There's no queued if the current is non recurring, represented by a discount rate of 1000000001.
-    if (_fundingCycle.discountRate == 1000000001) return _getStructFor(0, 0);
-
     // Check to see if this funding cycle's ballot is approved.
     // If so, return a funding cycle based on it.
     if (_isApproved(_projectId, _fundingCycle))
@@ -171,9 +168,6 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
 
       // Get the funding cycle for the latest ID.
       _fundingCycle = _getStructFor(_projectId, _fundingCycleConfiguration);
-
-      // There's no current if the latest is non recurring, represented by a discount rate of 1000000001.
-      if (_fundingCycle.discountRate == 1000000001) return _getStructFor(0, 0);
 
       // If it's not approved or if it hasn't yet started, get a reference to the funding cycle that the latest is based on, which has the latest approved configuration.
       if (!_isApproved(_projectId, _fundingCycle) || block.timestamp < _fundingCycle.start)
@@ -242,7 +236,6 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
       @dev _data.discountRate A number from 0-1000000000 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
         If it's 0, each funding cycle will have equal weight.
         If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
-        If the number is 1000000001, an non-recurring funding cycle will get made.
       @dev _data.ballot The new ballot that will be used to approve subsequent reconfigurations.
     @param _metadata Data to associate with this funding cycle configuration.
 
@@ -256,8 +249,8 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     // Duration must fit in a uint64, and must be greater than 1000 seconds to prevent manipulative miner behavior.
     require(_data.duration <= type(uint64).max && _data.duration > 1000, '0x15: BAD_DURATION');
 
-    // Discount rate token must be less than or equal to 100%. A value of 1000000001 means non-recurring.
-    require(_data.discountRate <= 1000000001, '0x16: BAD_DISCOUNT_RATE');
+    // Discount rate token must be less than or equal to 100%.
+    require(_data.discountRate <= 100000000, '0x16: BAD_DISCOUNT_RATE');
 
     // Weight must fit into a uint88.
     require(_data.weight <= type(uint88).max, '0x18: BAD_WEIGHT');
@@ -347,9 +340,6 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
 
     // Get the funding cycle for the configuration.
     JBFundingCycle memory _currentFundingCycle = _getStructFor(_projectId, _currentConfiguration);
-
-    // Make sure the funding cycle is recurring.
-    require(_currentFundingCycle.discountRate < 1000000001, '0x1c: NON_RECURRING');
 
     // Determine if the configurable funding cycle can only take effect on or after a certain date.
     // The ballot must have ended.
@@ -593,9 +583,6 @@ contract JBFundingCycleStore is JBControllerUtility, IJBFundingCycleStore {
     view
     returns (JBFundingCycle memory)
   {
-    // Can't mock a non recurring funding cycle.
-    if (_baseFundingCycle.discountRate == 1000000001) return _getStructFor(0, 0);
-
     // The distance of the current time to the start of the next possible funding cycle.
     // If the returned mock cycle must not yet have started, the start time of the mock must be in the future so no need to adjust backwards.
     // If the base funding cycle doesn't have a duration, no adjustment is necessary because the next cycle can start immediately.

--- a/contracts/structs/JBFundingCycle.sol
+++ b/contracts/structs/JBFundingCycle.sol
@@ -28,7 +28,6 @@ struct JBFundingCycle {
   // A number from 0-1000000000 indicating by how much the `weight` of the subsequent funding cycle should be reduced, if the project owner hasn't configured the subsequent funding cycle with an explicit `weight`.
   // If it's 0, each funding cycle will have equal weight.
   // If the number is 900000000, the next funding cycle will have a 10% smaller weight.
-  // If the number is 1000000001, the funding cycle is non-recurrin so there cannot be a next cycle.
   uint256 discountRate;
   // An address of a contract that says whether a proposed reconfiguration should be accepted or rejected.
   // It can be used to create rules around how a project owner can change funding cycle parameters over time.

--- a/contracts/structs/JBFundingCycleData.sol
+++ b/contracts/structs/JBFundingCycleData.sol
@@ -14,10 +14,8 @@ struct JBFundingCycleData {
   // A value of 1 means that no tokens should be minted regardless of how many ETH was paid. The protocol will set the stored weight value to 0.
   // A value of 1 X 10^18 means that one token should be minted per ETH received.
   uint256 weight;
-  // A number from 0-1000000001 indicating how valuable a contribution to this funding cycle is compared to previous funding cycles.
   // If it's 0, each funding cycle will have equal weight.
   // If the number is 900000000, a contribution to the next funding cycle will only give you 10% of tickets given to a contribution of the same amoutn during the current funding cycle.
-  // If the number is 1000000001, an non-recurring funding cycle will get made.
   uint256 discountRate;
   // An address of a contract that says whether a proposed reconfiguration should be accepted or rejected.
   IJBFundingCycleBallot ballot;


### PR DESCRIPTION
These haven't yet been used productively, and have only caused accidental misconfigurations.
I can't imagine a particularly productive use case for this given the campaigns we've empirically seen over the past 5 months of JB projects in the wild.

I suggest we remove it, which will also remove unneeded complexity. 