### PR TITLE
Remove superfluous testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,18 +40,5 @@ jobs:
           steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
           steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --prefer-offline
-      # Compile smart contracts
-      - name: Compile contracts
-        run: yarn compile
-      # A local blockchain is required in order for unit tests to run.
-      - name: Start local blockchain
-        run: yarn chain --network hardhat &>/dev/null &
-      # Give the local blockchain time to come up.
-      - name: Sleep
-        run: sleep 60
-      # Run tests.
-      - name: Run tests
-        run: yarn test
-      # Run code coverage.
-      - name: Code coverage
+      - name: Tests and code coverage
         run: node --require esm ./node_modules/.bin/hardhat coverage --network hardhat


### PR DESCRIPTION
Code cov already executes tests, compiles, and brings up a local chain – so we're effectively running all tests twice. We can remove all this noise.