### PR TITLE
project metadata mapped to domains

### DIFF
--- a/contracts/JBController.sol
+++ b/contracts/JBController.sol
@@ -22,6 +22,7 @@ import './structs/JBFundingCycleData.sol';
 import './structs/JBFundingCycleMetadata.sol';
 import './structs/JBFundAccessConstraints.sol';
 import './structs/JBGroupedSplits.sol';
+import './structs/JBProjectMetadataData.sol';
 
 // Inheritance
 import './interfaces/IJBController.sol';
@@ -261,7 +262,7 @@ contract JBController is IJBController, JBTerminalUtility, JBOperatable, Reentra
 
     @param _owner The address to set as the owner of the project. The project ERC-721 will be owned by this address.
     @param _handle The project's unique handle. This can be updated any time by the owner of the project.
-    @param _metadataCid A link to associate with the project. This can be updated any time by the owner of the project.
+    @param _projectMetadataData A link to associate with the project within a particular domain. This can be updated any time by the owner of the project.
     @param _data A JBFundingCycleData data structure that defines the project's first funding cycle. These properties will remain fixed for the duration of the funding cycle.
       @dev _data.target The amount that the project wants to payout during a funding cycle. Sent as a wad (18 decimals).
       @dev _data.currency The currency of the `target`. Send 0 for ETH or 1 for USD.
@@ -303,7 +304,7 @@ contract JBController is IJBController, JBTerminalUtility, JBOperatable, Reentra
   function launchProjectFor(
     address _owner,
     bytes32 _handle,
-    string calldata _metadataCid,
+    JBProjectMetadataData calldata _projectMetadataData,
     JBFundingCycleData calldata _data,
     JBFundingCycleMetadata calldata _metadata,
     uint256 _mustStartAtOrAfter,
@@ -324,7 +325,7 @@ contract JBController is IJBController, JBTerminalUtility, JBOperatable, Reentra
     }
 
     // Create the project for into the wallet of the message sender.
-    projectId = projects.createFor(_owner, _handle, _metadataCid);
+    projectId = projects.createFor(_owner, _handle, _projectMetadataData);
 
     // Set the this contract as the project's controller in the directory.
     directory.setControllerOf(projectId, this);

--- a/contracts/JBProjects.sol
+++ b/contracts/JBProjects.sol
@@ -56,8 +56,9 @@ contract JBProjects is ERC721, IJBProjects, JBOperatable {
     This is optional for each project.
 
     _projectId The ID of the project to which the URI belongs.
+    _domain The domain within which the metadata applies.
   */
-  mapping(uint256 => string) public override metadataCidOf;
+  mapping(uint256 => mapping(uint256 => string)) public override metadataCidOf;
 
   /** 
     @notice 
@@ -122,14 +123,14 @@ contract JBProjects is ERC721, IJBProjects, JBOperatable {
 
     @param _owner The address that will be the owner of the project.
     @param _handle A unique string to associate with the project that will resolve to its token ID.
-    @param _metadataCid An IPFS CID hash where metadata about the project has been uploaded. An empty string is acceptable if no metadata is being provided.
+    @param _metadataData An struct containing an IPFS CID hash where metadata about the project has been uploaded, and domain within which the metadata applies. An empty string is acceptable if no metadata is being provided.
 
     @return The token ID of the newly created project
   */
   function createFor(
     address _owner,
     bytes32 _handle,
-    string calldata _metadataCid
+    JBProjectMetadataData calldata _metadataData
   ) external override returns (uint256) {
     // Handle must exist.
     if (_handle == bytes32(0)) {
@@ -153,10 +154,11 @@ contract JBProjects is ERC721, IJBProjects, JBOperatable {
     // Store the project ID for the handle.
     idFor[_handle] = count;
 
-    // Set the URI if one was provided.
-    if (bytes(_metadataCid).length > 0) metadataCidOf[count] = _metadataCid;
+    // Set the URI if one was provided for the specified domain.
+    if (bytes(_metadataData.cid).length > 0)
+      metadataCidOf[count][_metadataData.domain] = _metadataData.cid;
 
-    emit Create(count, _owner, _handle, _metadataCid, msg.sender);
+    emit Create(count, _owner, _handle, _metadataData, msg.sender);
 
     return count;
   }
@@ -205,18 +207,17 @@ contract JBProjects is ERC721, IJBProjects, JBOperatable {
     Only a project's owner or operator can set its URI.
 
     @param _projectId The ID of the project who's URI is being changed.
-    @param _metadataCid The new IPFS CID hash where metadata about the project has been uploaded.
-
+    @param _metadataData An struct containing an IPFS CID hash where metadata about the project has been uploaded, and domain within which the metadata applies. An empty string is acceptable if no metadata is being provided.
   */
-  function setMetadataCidOf(uint256 _projectId, string calldata _metadataCid)
+  function setMetadataCidOf(uint256 _projectId, JBProjectMetadataData calldata _metadataData)
     external
     override
     requirePermission(ownerOf(_projectId), _projectId, JBOperations.SET_METADATA_CID)
   {
-    // Set the new uri.
-    metadataCidOf[_projectId] = _metadataCid;
+    // Set the new uri within the specified domain.
+    metadataCidOf[_projectId][_metadataData.domain] = _metadataData.cid;
 
-    emit SetUri(_projectId, _metadataCid, msg.sender);
+    emit SetUri(_projectId, _metadataData, msg.sender);
   }
 
   /**

--- a/contracts/interfaces/IJBProjects.sol
+++ b/contracts/interfaces/IJBProjects.sol
@@ -5,18 +5,20 @@ import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 
 import './IJBTerminal.sol';
 
+import './../structs/JBProjectMetadataData.sol';
+
 interface IJBProjects is IERC721 {
   event Create(
     uint256 indexed projectId,
     address indexed owner,
     bytes32 indexed handle,
-    string uri,
+    JBProjectMetadataData metadataData,
     address caller
   );
 
   event SetHandle(uint256 indexed projectId, bytes32 indexed handle, address caller);
 
-  event SetUri(uint256 indexed projectId, string uri, address caller);
+  event SetUri(uint256 indexed projectId, JBProjectMetadataData metadataData, address caller);
 
   event TransferHandle(
     uint256 indexed projectId,
@@ -44,7 +46,7 @@ interface IJBProjects is IERC721 {
 
   function count() external view returns (uint256);
 
-  function metadataCidOf(uint256 _projectId) external view returns (string memory);
+  function metadataCidOf(uint256 _projectId, uint256 _domain) external view returns (string memory);
 
   function handleOf(uint256 _projectId) external returns (bytes32 handle);
 
@@ -57,12 +59,13 @@ interface IJBProjects is IERC721 {
   function createFor(
     address _owner,
     bytes32 _handle,
-    string calldata _metadataCid
+    JBProjectMetadataData calldata _metadataData
   ) external returns (uint256 id);
 
   function setHandleOf(uint256 _projectId, bytes32 _handle) external;
 
-  function setMetadataCidOf(uint256 _projectId, string calldata _metadataCid) external;
+  function setMetadataCidOf(uint256 _projectId, JBProjectMetadataData calldata _metadataData)
+    external;
 
   function transferHandleOf(
     uint256 _projectId,

--- a/contracts/structs/JBProjectMetadataData.sol
+++ b/contracts/structs/JBProjectMetadataData.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+struct JBProjectMetadataData {
+  // An IPFS content ID where the metadata is found.
+  string cid;
+  // The domain within which the metadata applies.
+  uint256 domain;
+}


### PR DESCRIPTION
Projects can now set a metadataCid for any number of domain namespaces