### PR TITLE
Cleanup/record redemption adjustment

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -30,11 +30,9 @@ error INADEQUATE_TOKEN_COUNT();
 error INADEQUATE_WITHDRAW_AMOUNT();
 error INSUFFICIENT_TOKENS();
 error INVALID_FUNDING_CYCLE();
-error NO_CLAIMABLE_TOKENS();
 error PAYMENT_TERMINAL_MIGRATION_NOT_ALLOWED();
 error PAYMENT_TERMINAL_UNAUTHORIZED();
 error STORE_ALREADY_CLAIMED();
-error TOKEN_AMOUNT_ZERO();
 
 /**
   @notice
@@ -499,7 +497,7 @@ contract JBETHPaymentTerminalStore {
 
     @param _holder The account that is having its tokens redeemed.
     @param _projectId The ID of the project to which the tokens being redeemed belong.
-    @param _tokenCount The number of tokens to redeemed.
+    @param _tokenCount The number of tokens to redeem.
     @param _minReturnedWei The minimum amount of wei expected in return.
     @param _beneficiary The address that will benefit from the claimed amount.
     @param _memo A memo to pass along to the emitted event.

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -526,11 +526,6 @@ contract JBETHPaymentTerminalStore {
       string memory memo
     )
   {
-    // There must be some amount of tokens to record redemption for.
-    if (_tokenCount == 0) {
-      revert TOKEN_AMOUNT_ZERO();
-    }
-
     // The holder must have the specified number of the project's tokens.
     if (tokenStore.balanceOf(_holder, _projectId) < _tokenCount) {
       revert INSUFFICIENT_TOKENS();
@@ -566,11 +561,6 @@ contract JBETHPaymentTerminalStore {
       memo = _memo;
     }
 
-    // There must be something to claim.
-    if (claimAmount == 0) {
-      revert NO_CLAIMABLE_TOKENS();
-    }
-
     // The amount being claimed must be within the project's balance.
     if (claimAmount > balanceOf[_projectId]) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
@@ -581,16 +571,11 @@ contract JBETHPaymentTerminalStore {
     }
 
     // Redeem the tokens, which burns them.
-    directory.controllerOf(_projectId).burnTokensOf(
-      _holder,
-      _projectId,
-      _tokenCount,
-      'Redeem for ETH',
-      true
-    );
+    if (_tokenCount > 0)
+      directory.controllerOf(_projectId).burnTokensOf(_holder, _projectId, _tokenCount, '', false);
 
     // Remove the redeemed funds from the project's balance.
-    balanceOf[_projectId] = balanceOf[_projectId] - claimAmount;
+    if (claimAmount > 0) balanceOf[_projectId] = balanceOf[_projectId] - claimAmount;
 
     // If a delegate was returned by the data source, issue a callback to it.
     if (_delegate != IJBRedemptionDelegate(address(0))) {

--- a/test/jb_eth_payment_terminal_store/record_redemption_for.test.js
+++ b/test/jb_eth_payment_terminal_store/record_redemption_for.test.js
@@ -15,7 +15,7 @@ import jbPrices from '../../artifacts/contracts/interfaces/IJBPrices.sol/IJBPric
 import jbProjects from '../../artifacts/contracts/interfaces/IJBProjects.sol/IJBProjects.json';
 import jbTokenStore from '../../artifacts/contracts/interfaces/IJBTokenStore.sol/IJBTokenStore.json';
 
-describe.only('JBETHPaymentTerminalStore::recordRedemptionFor(...)', function () {
+describe('JBETHPaymentTerminalStore::recordRedemptionFor(...)', function () {
   const PROJECT_ID = 2;
   const AMOUNT = ethers.FixedNumber.fromString('4398541.345');
   const WEIGHT = ethers.FixedNumber.fromString('900000000.23411');

--- a/test/jb_eth_payment_terminal_store/record_redemption_for.test.js
+++ b/test/jb_eth_payment_terminal_store/record_redemption_for.test.js
@@ -241,7 +241,7 @@ describe('JBETHPaymentTerminalStore::recordRedemptionFor(...)', function () {
         /* delegateMetadata */ 0,
       );
 
-    // Expect recorded balance to decrease by redeemed amount
+    // Expect recorded balance to not have changed
     expect(await jbEthPaymentTerminalStore.balanceOf(PROJECT_ID)).to.equal(startingBalance);
   });
 
@@ -309,7 +309,7 @@ describe('JBETHPaymentTerminalStore::recordRedemptionFor(...)', function () {
       )
       .returns();
 
-    // Add to balance beforehand to have sufficient overflow
+    // No balance
     const startingBalance = 0;
 
     expect(await jbEthPaymentTerminalStore.balanceOf(PROJECT_ID)).to.equal(startingBalance);
@@ -327,7 +327,7 @@ describe('JBETHPaymentTerminalStore::recordRedemptionFor(...)', function () {
         /* delegateMetadata */ 0,
       );
 
-    // Expect recorded balance to decrease by redeemed amount
+    // Expect recorded balance to not have changed
     expect(await jbEthPaymentTerminalStore.balanceOf(PROJECT_ID)).to.equal(
       startingBalance,
     );


### PR DESCRIPTION
recordRedemption should access no tokens being redeemed and no tokens being claimed. This'll allow dataSources and delegates to work override all default behavior.