### PR TITLE
send arg as struct

### DIFF
--- a/contracts/JBController.sol
+++ b/contracts/JBController.sol
@@ -835,11 +835,9 @@ contract JBController is IJBController, JBOperatable, ReentrancyGuard {
         if (_split.allocator != IJBSplitAllocator(address(0)))
           _split.allocator.allocate(
             _tokenCount,
-            JBSplitsGroups.RESERVED_TOKENS,
             _projectId,
-            _split.projectId,
-            _split.beneficiary,
-            _split.preferClaimed
+            JBSplitsGroups.RESERVED_TOKENS,
+            _split
           );
 
         // Subtract from the amount to be sent to the beneficiary.

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -621,11 +621,9 @@ contract JBETHPaymentTerminal is
         if (_split.allocator != IJBSplitAllocator(address(0))) {
           _split.allocator.allocate{value: _payoutAmount}(
             _payoutAmount,
-            JBSplitsGroups.ETH_PAYOUT,
             _projectId,
-            _split.projectId,
-            _split.beneficiary,
-            _split.preferClaimed
+            JBSplitsGroups.ETH_PAYOUT,
+            _split
           );
           // Otherwise, if a project is specified, make a payment to it.
         } else if (_split.projectId != 0) {

--- a/contracts/interfaces/IJBSplitAllocator.sol
+++ b/contracts/interfaces/IJBSplitAllocator.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
+import '../structs/JBSplit.sol';
+
 interface IJBSplitAllocator {
   function allocate(
     uint256 _amount,
-    uint256 _group,
     uint256 _projectId,
-    uint256 _forProjectId,
-    address _beneficiary,
-    bool _preferClaimed
+    uint256 _group,
+    JBSplit calldata _split
   ) external payable;
 }

--- a/test/jb_controller/distribute_reserved_token_of.test.js
+++ b/test/jb_controller/distribute_reserved_token_of.test.js
@@ -300,15 +300,13 @@ describe('JBController::distributeReservedTokensOf(...)', function () {
       .returns();
 
     await Promise.all(
-      splitsBeneficiariesAddresses.map(async (beneficiary) => {
+      splits.map(async (split) => {
         await mockJbAllocator.mock.allocate
           .withArgs(
-            /*amount=*/ Math.floor(RESERVED_AMOUNT / splitsBeneficiariesAddresses.length),
-            /*group=*/ RESERVED_SPLITS_GROUP,
+            /*amount=*/ Math.floor(RESERVED_AMOUNT / splits.length),
             PROJECT_ID,
-            otherProjectId,
-            beneficiary,
-            PREFERED_CLAIMED_TOKEN,
+            /*group=*/ RESERVED_SPLITS_GROUP,
+            split
           )
           .returns();
       }),

--- a/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
+++ b/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
@@ -871,11 +871,9 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
         await mockJbAllocator.mock.allocate
           .withArgs(
             Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
-            ETH_PAYOUT_INDEX,
             PROJECT_ID,
-            split.projectId,
-            split.beneficiary,
-            split.preferClaimed,
+            ETH_PAYOUT_INDEX,
+            split
           )
           .returns();
       }),


### PR DESCRIPTION
Send arg as struct to reduce arg count, creating more space for local vars before stack too deep.