### PR TITLE
accomodate 0 currency

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -765,7 +765,8 @@ contract JBETHPaymentTerminalStore {
     // Convert the _distributionRemaining to ETH.
     uint256 _ethDistributionRemaining = _distributionRemaining == 0
       ? 0
-      : (_currency == JBCurrencies.ETH)
+      : // _currency of 0 means the terminal's native token should be used.
+      (_currency == 0 || _currency == JBCurrencies.ETH)
       ? _distributionRemaining
       : PRBMathUD60x18.div(_distributionRemaining, prices.priceFor(_currency, JBCurrencies.ETH));
 
@@ -818,7 +819,8 @@ contract JBETHPaymentTerminalStore {
       _ethDistributionLimitRemaining =
         _ethDistributionLimitRemaining +
         (
-          _distributionRemaining == 0 ? 0 : (_currency == JBCurrencies.ETH)
+          // _currency of 0 means the terminal's native token should be used.
+          _distributionRemaining == 0 ? 0 : (_currency == 0 || _currency == JBCurrencies.ETH)
             ? _distributionRemaining
             : PRBMathUD60x18.div(
               _distributionRemaining,


### PR DESCRIPTION
A currency of 0 for a `distributionLimit` or an `overflowAllowance` suggests the native token of the terminal should be used as the currency.

The overflow calculations weren't taking this into account.