### PR TITLE
fix: critical - recordUsedAllowanceOf

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -475,13 +475,21 @@ contract JBETHPaymentTerminalStore {
     withdrawnAmount = (_currency == JBCurrencies.ETH)
       ? _amount
       : PRBMathUD60x18.div(_amount, prices.priceFor(_currency, JBCurrencies.ETH));
-
+    
     // Get the current funding target
     uint256 distributionLimit =
       directory.controllerOf(_projectId).distributionLimitOf(
         _projectId,
         fundingCycle.configuration,
         terminal
+      );
+
+    // Convert the target into wei, if needed
+    distributionLimit = _currency == JBCurrencies.ETH
+      ? distributionLimit
+      : PRBMathUD60x18.div(
+        distributionLimit,
+        prices.priceFor(_currency, JBCurrencies.ETH)
       );
 
     // The amount being withdrawn must be available in the overflow.

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -483,17 +483,20 @@ contract JBETHPaymentTerminalStore {
         fundingCycle.configuration,
         terminal
       );
+    
+    // The current overflow is the balance minus what still needs to be distributed
+    uint256 _leftToDistribute = distributionLimit - usedDistributionLimitOf[_projectId][fundingCycle.number];
 
-    // Convert the target into wei, if needed
-    distributionLimit = _currency == JBCurrencies.ETH
-      ? distributionLimit
+    // Convert the remaining to distribute into wei, if needed
+    _leftToDistribute = _currency == JBCurrencies.ETH
+      ? _leftToDistribute
       : PRBMathUD60x18.div(
-        distributionLimit,
+        _leftToDistribute,
         prices.priceFor(_currency, JBCurrencies.ETH)
       );
 
     // The amount being withdrawn must be available in the overflow.
-    if (withdrawnAmount > balanceOf[_projectId] + usedDistributionLimitOf[_projectId][fundingCycle.number] - distributionLimit) {
+    if (withdrawnAmount > balanceOf[_projectId] - _leftToDistribute) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
     }
 

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -476,8 +476,16 @@ contract JBETHPaymentTerminalStore {
       ? _amount
       : PRBMathUD60x18.div(_amount, prices.priceFor(_currency, JBCurrencies.ETH));
 
-    // The amount being withdrawn must be available.
-    if (withdrawnAmount > balanceOf[_projectId]) {
+    // Get the current funding target
+    uint256 distributionLimit =
+      directory.controllerOf(_projectId).distributionLimitOf(
+        _projectId,
+        fundingCycle.configuration,
+        terminal
+      );
+
+    // The amount being withdrawn must be available in the overflow.
+    if (withdrawnAmount > balanceOf[_projectId] + usedDistributionLimitOf[_projectId][fundingCycle.number] - distributionLimit) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
     }
 

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -364,6 +364,21 @@ contract JBETHPaymentTerminalStore {
       revert FUNDING_CYCLE_DISTRIBUTION_PAUSED();
     }
 
+    // The new total amount that has been distributed during this funding cycle.
+    uint256 _newUsedDistributionLimitOf = usedDistributionLimitOf[_projectId][fundingCycle.number] +
+      _amount;
+
+    // Amount must be within what is still distributable.
+    uint256 _distributionLimitOf = directory.controllerOf(_projectId).distributionLimitOf(
+        _projectId,
+        fundingCycle.configuration,
+        terminal
+      );
+
+    if (_newUsedDistributionLimitOf > _distributionLimitOf || _distributionLimitOf == 0) {
+      revert DISTRIBUTION_AMOUNT_LIMIT_REACHED();
+    }
+
     // Make sure the currencies match.
     if (
       _currency !=
@@ -374,22 +389,6 @@ contract JBETHPaymentTerminalStore {
       )
     ) {
       revert CURRENCY_MISMATCH();
-    }
-
-    // The new total amount that has been distributed during this funding cycle.
-    uint256 _newUsedDistributionLimitOf = usedDistributionLimitOf[_projectId][fundingCycle.number] +
-      _amount;
-
-    // Amount must be within what is still distributable.
-    if (
-      _newUsedDistributionLimitOf >
-      directory.controllerOf(_projectId).distributionLimitOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      )
-    ) {
-      revert DISTRIBUTION_AMOUNT_LIMIT_REACHED();
     }
 
     // Convert the amount to wei.
@@ -442,6 +441,22 @@ contract JBETHPaymentTerminalStore {
     // Get a reference to the project's current funding cycle.
     fundingCycle = fundingCycleStore.currentOf(_projectId);
 
+    // Get a reference to the new used overflow allowance.
+    uint256 _newUsedOverflowAllowanceOf = usedOverflowAllowanceOf[_projectId][
+      fundingCycle.configuration
+    ] + _amount;
+
+    // There must be sufficient allowance available.
+    uint256 _allowanceOf = directory.controllerOf(_projectId).overflowAllowanceOf(
+        _projectId,
+        fundingCycle.configuration,
+        terminal
+      );
+
+    if(_newUsedOverflowAllowanceOf > _allowanceOf || _allowanceOf == 0) {
+      revert INADEQUATE_CONTROLLER_ALLOWANCE();
+    }
+
     // Make sure the currencies match.
     if (
       _currency !=
@@ -452,23 +467,6 @@ contract JBETHPaymentTerminalStore {
       )
     ) {
       revert CURRENCY_MISMATCH();
-    }
-
-    // Get a reference to the new used overflow allowance.
-    uint256 _newUsedOverflowAllowanceOf = usedOverflowAllowanceOf[_projectId][
-      fundingCycle.configuration
-    ] + _amount;
-
-    // There must be sufficient allowance available.
-    if (
-      _newUsedOverflowAllowanceOf >
-      directory.controllerOf(_projectId).overflowAllowanceOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      )
-    ) {
-      revert INADEQUATE_CONTROLLER_ALLOWANCE();
     }
 
     // Convert the amount to wei.
@@ -496,7 +494,7 @@ contract JBETHPaymentTerminalStore {
       );
 
     // The amount being withdrawn must be available in the overflow.
-    if (withdrawnAmount > balanceOf[_projectId] - _leftToDistribute) {
+    if (balanceOf[_projectId] == 0 || withdrawnAmount > balanceOf[_projectId] - _leftToDistribute) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
     }
 

--- a/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
+++ b/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
@@ -202,6 +202,10 @@ describe('JBETHPaymentTerminalStore::recordDistributionFor(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
 
+    await mockJbController.mock.distributionLimitOf
+    .withArgs(PROJECT_ID, timestamp, terminal.address)
+    .returns(AMOUNT);
+
     // Record the distributions
     await expect(
       jbEthPaymentTerminalStore

--- a/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
+++ b/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
@@ -202,10 +202,6 @@ describe('JBETHPaymentTerminalStore::recordDistributionFor(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
 
-    await mockJbController.mock.distributionLimitOf
-    .withArgs(PROJECT_ID, timestamp, terminal.address)
-    .returns(AMOUNT);
-
     // Record the distributions
     await expect(
       jbEthPaymentTerminalStore

--- a/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
@@ -103,14 +103,18 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await mockJbController.mock.distributionLimitOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(0);
-
-    await mockJbController.mock.overflowAllowanceCurrencyOf
+    
+    await mockJbController.mock.distributionLimitCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
 
     await mockJbController.mock.overflowAllowanceOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(AMOUNT);
+    
+    await mockJbController.mock.overflowAllowanceCurrencyOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(CURRENCY_USD);
 
     await mockJbPrices.mock.priceFor.withArgs(CURRENCY_USD, CURRENCY_ETH).returns(usdToEthPrice);
 
@@ -158,10 +162,6 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
-
-    await mockJbController.mock.overflowAllowanceOf
-      .withArgs(PROJECT_ID, timestamp, terminal.address)
-      .returns(AMOUNT);
 
     // Record the used allowance
     await expect(
@@ -227,13 +227,17 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(smallBalance);
 
-    await mockJbController.mock.overflowAllowanceCurrencyOf
+    await mockJbController.mock.distributionLimitCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_ETH);
 
     await mockJbController.mock.overflowAllowanceOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(AMOUNT);
+
+    await mockJbController.mock.overflowAllowanceCurrencyOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(CURRENCY_ETH);
 
     await mockJbPrices.mock.priceFor
       .withArgs(CURRENCY_ETH, CURRENCY_ETH)
@@ -266,14 +270,18 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(0);
 
-    await mockJbController.mock.overflowAllowanceCurrencyOf
+    await mockJbController.mock.distributionLimitCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_ETH);
-
+      
     await mockJbController.mock.overflowAllowanceOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(AMOUNT);
 
+    await mockJbController.mock.overflowAllowanceCurrencyOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(CURRENCY_ETH);
+      
     await mockJbPrices.mock.priceFor
       .withArgs(CURRENCY_ETH, CURRENCY_ETH)
       .returns(ethers.FixedNumber.from(1));

--- a/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
@@ -159,6 +159,10 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
 
+    await mockJbController.mock.overflowAllowanceOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(AMOUNT);
+
     // Record the used allowance
     await expect(
       jbEthPaymentTerminalStore


### PR DESCRIPTION
Fix bug where projectOwner could use its overflow allowance to take both overflow and target funds.

Solution: compare the used overflow allowance to the remaining overflow (instead of comparing to the whole project balance).