### PR TITLE
fix: low - assertion reorder + mock init in tests

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -473,25 +473,9 @@ contract JBETHPaymentTerminalStore {
     withdrawnAmount = (_currency == JBCurrencies.ETH)
       ? _amount
       : PRBMathUD60x18.div(_amount, prices.priceFor(_currency, JBCurrencies.ETH));
-    
-    // Get the current funding target
-    uint256 distributionLimit =
-      directory.controllerOf(_projectId).distributionLimitOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      );
-
-    // Convert the target into wei, if needed
-    distributionLimit = _currency == JBCurrencies.ETH
-      ? distributionLimit
-      : PRBMathUD60x18.div(
-        distributionLimit,
-        prices.priceFor(_currency, JBCurrencies.ETH)
-      );
-
-    // The amount being withdrawn must be available in the overflow.
-    if (withdrawnAmount > balanceOf[_projectId] + usedDistributionLimitOf[_projectId][fundingCycle.number] - distributionLimit) {
+      
+    // The amount being withdrawn must be available.
+    if (withdrawnAmount > balanceOf[_projectId]) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
     }
 

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -364,18 +364,6 @@ contract JBETHPaymentTerminalStore {
       revert FUNDING_CYCLE_DISTRIBUTION_PAUSED();
     }
 
-    // Make sure the currencies match.
-    if (
-      _currency !=
-      directory.controllerOf(_projectId).distributionLimitCurrencyOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      )
-    ) {
-      revert CURRENCY_MISMATCH();
-    }
-
     // The new total amount that has been distributed during this funding cycle.
     uint256 _newUsedDistributionLimitOf = usedDistributionLimitOf[_projectId][fundingCycle.number] +
       _amount;
@@ -390,6 +378,18 @@ contract JBETHPaymentTerminalStore {
       )
     ) {
       revert DISTRIBUTION_AMOUNT_LIMIT_REACHED();
+    }
+
+    // Make sure the currencies match.
+    if (
+      _currency !=
+      directory.controllerOf(_projectId).distributionLimitCurrencyOf(
+        _projectId,
+        fundingCycle.configuration,
+        terminal
+      )
+    ) {
+      revert CURRENCY_MISMATCH();
     }
 
     // Convert the amount to wei.
@@ -442,18 +442,6 @@ contract JBETHPaymentTerminalStore {
     // Get a reference to the project's current funding cycle.
     fundingCycle = fundingCycleStore.currentOf(_projectId);
 
-    // Make sure the currencies match.
-    if (
-      _currency !=
-      directory.controllerOf(_projectId).overflowAllowanceCurrencyOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      )
-    ) {
-      revert CURRENCY_MISMATCH();
-    }
-
     // Get a reference to the new used overflow allowance.
     uint256 _newUsedOverflowAllowanceOf = usedOverflowAllowanceOf[_projectId][
       fundingCycle.configuration
@@ -469,6 +457,18 @@ contract JBETHPaymentTerminalStore {
       )
     ) {
       revert INADEQUATE_CONTROLLER_ALLOWANCE();
+    }
+
+    // Make sure the currencies match.
+    if (
+      _currency !=
+      directory.controllerOf(_projectId).overflowAllowanceCurrencyOf(
+        _projectId,
+        fundingCycle.configuration,
+        terminal
+      )
+    ) {
+      revert CURRENCY_MISMATCH();
     }
 
     // Convert the amount to wei.

--- a/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
+++ b/test/jb_eth_payment_terminal_store/record_distribution_for.test.js
@@ -201,6 +201,10 @@ describe('JBETHPaymentTerminalStore::recordDistributionFor(...)', function () {
     await mockJbController.mock.distributionLimitCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
+    
+    await mockJbController.mock.distributionLimitOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(AMOUNT);
 
     // Record the distributions
     await expect(

--- a/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
@@ -155,6 +155,10 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
 
+    await mockJbController.mock.overflowAllowanceOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(AMOUNT);
+
     // Record the used allowance
     await expect(
       jbEthPaymentTerminalStore

--- a/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
@@ -99,6 +99,10 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await jbEthPaymentTerminalStore
       .connect(terminal)
       .recordAddedBalanceFor(PROJECT_ID, amountInWei);
+    
+    await mockJbController.mock.distributionLimitOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(0);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
@@ -201,7 +205,7 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     ).to.be.revertedWith(errors.INADEQUATE_CONTROLLER_ALLOWANCE);
   });
 
-  it(`Can't record allowance if withdrawnAmount > project's total balance`, async function () {
+  it(`Can't record allowance if withdrawnAmount > overflow`, async function () {
     const {
       terminal,
       mockJbController,
@@ -213,9 +217,15 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
 
     // Add to balance beforehand
     const smallBalance = AMOUNT.subUnsafe(ethers.FixedNumber.from(1));
+
     await jbEthPaymentTerminalStore
       .connect(terminal)
-      .recordAddedBalanceFor(PROJECT_ID, smallBalance);
+      .recordAddedBalanceFor(PROJECT_ID, AMOUNT);
+    
+    // Leave a small overflow
+    await mockJbController.mock.distributionLimitOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(smallBalance);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
@@ -248,8 +258,13 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       CURRENCY_ETH,
     } = await setup();
 
-    // Add to balance beforehand
-    await jbEthPaymentTerminalStore.connect(terminal).recordAddedBalanceFor(PROJECT_ID, AMOUNT);
+    await jbEthPaymentTerminalStore
+      .connect(terminal)
+      .recordAddedBalanceFor(PROJECT_ID, AMOUNT);
+    
+    await mockJbController.mock.distributionLimitOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(0);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)

--- a/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal_store/record_used_allowance_of.test.js
@@ -99,10 +99,6 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await jbEthPaymentTerminalStore
       .connect(terminal)
       .recordAddedBalanceFor(PROJECT_ID, amountInWei);
-    
-    await mockJbController.mock.distributionLimitOf
-      .withArgs(PROJECT_ID, timestamp, terminal.address)
-      .returns(0);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
@@ -111,6 +107,10 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await mockJbController.mock.overflowAllowanceOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(AMOUNT);
+
+    await mockJbController.mock.distributionLimitOf
+      .withArgs(PROJECT_ID, timestamp, terminal.address)
+      .returns(0);
 
     await mockJbPrices.mock.priceFor.withArgs(CURRENCY_USD, CURRENCY_ETH).returns(usdToEthPrice);
 
@@ -158,7 +158,7 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(CURRENCY_USD);
-
+    
     await mockJbController.mock.overflowAllowanceOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
       .returns(AMOUNT);
@@ -205,7 +205,7 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
     ).to.be.revertedWith(errors.INADEQUATE_CONTROLLER_ALLOWANCE);
   });
 
-  it(`Can't record allowance if withdrawnAmount > overflow`, async function () {
+  it(`Can't record allowance if withdrawnAmount > project's total balance`, async function () {
     const {
       terminal,
       mockJbController,
@@ -217,15 +217,9 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
 
     // Add to balance beforehand
     const smallBalance = AMOUNT.subUnsafe(ethers.FixedNumber.from(1));
-
     await jbEthPaymentTerminalStore
       .connect(terminal)
-      .recordAddedBalanceFor(PROJECT_ID, AMOUNT);
-    
-    // Leave a small overflow
-    await mockJbController.mock.distributionLimitOf
-      .withArgs(PROJECT_ID, timestamp, terminal.address)
-      .returns(smallBalance);
+      .recordAddedBalanceFor(PROJECT_ID, smallBalance);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)
@@ -258,13 +252,8 @@ describe('JBETHPaymentTerminalStore::recordUsedAllowanceOf(...)', function () {
       CURRENCY_ETH,
     } = await setup();
 
-    await jbEthPaymentTerminalStore
-      .connect(terminal)
-      .recordAddedBalanceFor(PROJECT_ID, AMOUNT);
-    
-    await mockJbController.mock.distributionLimitOf
-      .withArgs(PROJECT_ID, timestamp, terminal.address)
-      .returns(0);
+    // Add to balance beforehand
+    await jbEthPaymentTerminalStore.connect(terminal).recordAddedBalanceFor(PROJECT_ID, AMOUNT);
 
     await mockJbController.mock.overflowAllowanceCurrencyOf
       .withArgs(PROJECT_ID, timestamp, terminal.address)


### PR DESCRIPTION
This PR fix the order of the tests in JBETHPaymentTerminalStore where in both recordUsedAllowance and recordDistributionFor the currency was assessed before testing the related amounts (ie resp the new allowance left and the new distribution left) 
-> the currency for a 0 allowance or distributionLimit being 0 (and ETH being the currency number 1), this lead to reverting with CURRENCY_MISMATCH() (instead of DISTRIBUTION_AMOUNT_LIMIT_REACHED() or INADEQUATE_CONTROLLER_ALLOWANCE()) when using the 0 allowance or distribution.

Fix: testing for those amounts before checking the currency