### PR TITLE
fix: minor - currency for 0 distribution limit

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -492,7 +492,7 @@ contract JBETHPaymentTerminalStore {
       );
 
     // Convert the remaining to distribute into wei, if needed
-    _leftToDistribute = _distributionLimitCurrency == JBCurrencies.ETH
+    _leftToDistribute = (_distributionLimitCurrency == JBCurrencies.ETH || _distributionLimitCurrency == 0)
       ? _leftToDistribute
       : PRBMathUD60x18.div(
         _leftToDistribute,


### PR DESCRIPTION
When setting a 0 distribution limit (ie all the balance is in overflow), a default target currency is set as "0". When using the allowance on this overflow, it will revert since we try to get a price for the currency 0.
-> fix: is the distribution currency is 0, treat it as it was already in wei.
(minor as in prod, project owner can fix this by setting the distribution currency to ETH or any other non-invalid currency)