### PR TITLE
fix: revert on invalid currency

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -492,7 +492,7 @@ contract JBETHPaymentTerminalStore {
       );
 
     // Convert the remaining to distribute into wei, if needed
-    _leftToDistribute = (_distributionLimitCurrency == JBCurrencies.ETH || _distributionLimitCurrency == 0)
+    _leftToDistribute = (_distributionLimitCurrency == JBCurrencies.ETH || distributionLimit == 0)
       ? _leftToDistribute
       : PRBMathUD60x18.div(
         _leftToDistribute,

--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -482,26 +482,28 @@ contract JBETHPaymentTerminalStore {
         terminal
       );
 
-    uint256 _leftToDistribute = distributionLimit - usedDistributionLimitOf[_projectId][fundingCycle.number];
+    if(distributionLimit > 0) {
+      uint256 _leftToDistribute = distributionLimit - usedDistributionLimitOf[_projectId][fundingCycle.number];
 
-    // Get the distribution limit currency (which might or might not be the same as the overflow allowance)
-    uint256 _distributionLimitCurrency = directory.controllerOf(_projectId).distributionLimitCurrencyOf(
-        _projectId,
-        fundingCycle.configuration,
-        terminal
-      );
+      // Get the distribution limit currency (which might or might not be the same as the overflow allowance)
+      uint256 _distributionLimitCurrency = directory.controllerOf(_projectId).distributionLimitCurrencyOf(
+          _projectId,
+          fundingCycle.configuration,
+          terminal
+        );
 
-    // Convert the remaining to distribute into wei, if needed
-    _leftToDistribute = (_distributionLimitCurrency == JBCurrencies.ETH || distributionLimit == 0)
-      ? _leftToDistribute
-      : PRBMathUD60x18.div(
-        _leftToDistribute,
-        prices.priceFor(_distributionLimitCurrency, JBCurrencies.ETH)
-      );
+      // Convert the remaining to distribute into wei, if needed
+      _leftToDistribute = (_distributionLimitCurrency == JBCurrencies.ETH)
+        ? _leftToDistribute
+        : PRBMathUD60x18.div(
+          _leftToDistribute,
+          prices.priceFor(_distributionLimitCurrency, JBCurrencies.ETH)
+        );
 
-    // The amount being withdrawn must be available in the overflow.
-    if (_leftToDistribute > balanceOf[_projectId] || withdrawnAmount > balanceOf[_projectId] - _leftToDistribute) {
-      revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
+      // The amount being withdrawn must be available in the overflow.
+      if (_leftToDistribute > balanceOf[_projectId] || withdrawnAmount > balanceOf[_projectId] - _leftToDistribute) {
+        revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
+      }
     }
 
     // The amount being withdrawn must be at least as much as was expected.


### PR DESCRIPTION
When setting a 0 distribution limit (ie all the balance is in overflow), a default target currency was set as "0", fixed in the previous commit.
-> change to: if the distribution limit itself is 0, treat it as it was already in wei (and let it revert if a non-0 distribution limit has an invalid currency, as an extra-safety net)