### PR TITLE
Payout splits to other projects bypass protocol fees. 

### DIFF
--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -663,6 +663,8 @@ contract JBETHPaymentTerminal is
         JBConstants.SPLITS_TOTAL_PERCENT
       );
 
+      uint256 _netPayoutAmount = _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount);
+
       if (_payoutAmount > 0) {
         // Transfer ETH to the mod.
         // If there's an allocator set, transfer to its `allocate` function.
@@ -671,7 +673,7 @@ contract JBETHPaymentTerminal is
           feeEligibleDistributionAmount += _payoutAmount;
 
           _split.allocator.allocate{value: _payoutAmount}(
-            _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount),
+            _netPayoutAmount,
             _projectId,
             JBSplitsGroups.ETH_PAYOUT,
             _split
@@ -698,11 +700,12 @@ contract JBETHPaymentTerminal is
               '',
               bytes('')
             );
+            _netPayoutAmount = _payoutAmount; // For the event
           } else {
             // This distribution is eligible for a fee since the funds are leaving this contract.
             feeEligibleDistributionAmount += _payoutAmount;
 
-            _terminal.pay{value: _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount)}(
+            _terminal.pay{value: _netPayoutAmount}(
               _split.projectId,
               _split.beneficiary,
               0,
@@ -718,7 +721,7 @@ contract JBETHPaymentTerminal is
           // Otherwise, send the funds directly to the beneficiary.
           Address.sendValue(
             _split.beneficiary,
-            _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount)
+            _netPayoutAmount
           );
         }
 
@@ -731,7 +734,7 @@ contract JBETHPaymentTerminal is
         _fundingCycle.number,
         _projectId,
         _split,
-        _payoutAmount,
+        _netPayoutAmount,
         msg.sender
       );
     }

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -663,7 +663,8 @@ contract JBETHPaymentTerminal is
         JBConstants.SPLITS_TOTAL_PERCENT
       );
 
-      uint256 _netPayoutAmount = _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount);
+      // The payout amount substracting any incurred fees (the platform project doesn't pays fee to itself)
+      uint256 _netPayoutAmount = _projectId == 1 ? _payoutAmount : _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount);
 
       if (_payoutAmount > 0) {
         // Transfer ETH to the mod.
@@ -690,8 +691,9 @@ contract JBETHPaymentTerminal is
 
           // Save gas if this contract is being used as the terminal.
           if (_terminal == this) {
+            _netPayoutAmount = _payoutAmount; // This distribution is not eligible for a fee, reassigned for the event
             _pay(
-              _payoutAmount,
+              _netPayoutAmount,
               address(this),
               _split.projectId,
               _split.beneficiary,
@@ -700,7 +702,6 @@ contract JBETHPaymentTerminal is
               '',
               bytes('')
             );
-            _netPayoutAmount = _payoutAmount; // For the event
           } else {
             // This distribution is eligible for a fee since the funds are leaving this contract.
             feeEligibleDistributionAmount += _payoutAmount;

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -699,7 +699,10 @@ contract JBETHPaymentTerminal is
               bytes('')
             );
           } else {
-            _terminal.pay{value: _payoutAmount}(
+            // This distribution is eligible for a fee since the funds are leaving this contract.
+            feeEligibleDistributionAmount += _payoutAmount;
+
+            _terminal.pay{value: _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount)}(
               _split.projectId,
               _split.beneficiary,
               0,

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -673,7 +673,7 @@ contract JBETHPaymentTerminal is
           // This distribution is eligible for a fee since the funds are leaving the ecosystem.
           feeEligibleDistributionAmount += _payoutAmount;
 
-          _split.allocator.allocate{value: _payoutAmount}(
+          _split.allocator.allocate{value: _netPayoutAmount}(
             _netPayoutAmount,
             _projectId,
             JBSplitsGroups.ETH_PAYOUT,

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -339,7 +339,7 @@ contract JBETHPaymentTerminal is
       _feeEligibleDistributionAmount += _leftoverDistributionAmount;
 
       // Take the fee.
-      _feeAmount = fee == 0 || _feeEligibleDistributionAmount == 0 || _projectId == 1
+      _feeAmount = _projectId == 1 || _feeEligibleDistributionAmount == 0 || fee == 0
         ? 0
         : _takeFeeFrom(
           _projectId,
@@ -690,7 +690,7 @@ contract JBETHPaymentTerminal is
         JBConstants.SPLITS_TOTAL_PERCENT
       );
 
-      // The payout amount substracting any incurred fees (the platform project doesn't pays fee to itself)
+      // The payout amount substracting any incurred fees (the platform project doesn't pay fee to itself)
       uint256 _netPayoutAmount = _projectId == 1
         ? _payoutAmount
         : _payoutAmount - _getFeeAmount(_payoutAmount, _feeDiscount);

--- a/contracts/interfaces/IJBETHPaymentTerminal.sol
+++ b/contracts/interfaces/IJBETHPaymentTerminal.sol
@@ -77,6 +77,8 @@ interface IJBETHPaymentTerminal {
 
   event SetFeeGauge(IJBFeeGauge feeGauge, address caller);
 
+  event SetFeelessTerminal(IJBTerminal terminal, address caller);
+
   function projects() external view returns (IJBProjects);
 
   function splitsStore() external view returns (IJBSplitsStore);
@@ -88,6 +90,8 @@ interface IJBETHPaymentTerminal {
   function fee() external view returns (uint256);
 
   function feeGauge() external view returns (IJBFeeGauge);
+
+  function isFeelessTerminal(IJBTerminal _terminal) external view returns (bool);
 
   function distributePayoutsOf(
     uint256 _projectId,
@@ -116,4 +120,12 @@ interface IJBETHPaymentTerminal {
   ) external;
 
   function migrate(uint256 _projectId, IJBTerminal _to) external;
+
+  function processFees(uint256 _projectId) external;
+
+  function setFee(uint256 _fee) external;
+
+  function setFeeGauge(IJBFeeGauge _feeGauge) external;
+
+  function toggleFeelessTerminal(IJBTerminal _terminal) external;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/jbx-protocol/juice-contracts/"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
+++ b/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
@@ -13,7 +13,7 @@ import jbOperatoreStore from '../../artifacts/contracts/JBOperatorStore.sol/JBOp
 import jbProjects from '../../artifacts/contracts/JBProjects.sol/JBProjects.json';
 import jbSplitsStore from '../../artifacts/contracts/JBSplitsStore.sol/JBSplitsStore.json';
 
-describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
+describe.only('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
   const PLATFORM_PROJECT_ID = 1;
   const PROJECT_ID = 2;
   const OTHER_PROJECT_ID = 3;
@@ -476,7 +476,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
               split.lockedUntil,
               split.allocator,
             ],
-            /*payoutAmount*/ Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
+            /*payoutAmount*/ Math.floor((AMOUNT_MINUS_FEES * split.percent) / SPLITS_TOTAL_PERCENT),
             caller.address,
           );
       }),
@@ -580,7 +580,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
               split.lockedUntil,
               split.allocator,
             ],
-            /*payoutAmount*/ Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
+            /*payoutAmount*/ Math.floor((AMOUNT_MINUS_FEES * split.percent) / SPLITS_TOTAL_PERCENT),
             caller.address,
           );
       }),
@@ -680,7 +680,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
               split.lockedUntil,
               split.allocator,
             ],
-            /*payoutAmount*/ Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
+            /*payoutAmount*/ Math.floor((AMOUNT_MINUS_FEES * split.percent) / SPLITS_TOTAL_PERCENT),
             caller.address,
           )
           .and.to.emit(jbEthPaymentTerminal, 'Pay')
@@ -805,7 +805,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
               split.lockedUntil,
               split.allocator,
             ],
-            /*payoutAmount*/ Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
+            /*payoutAmount*/ Math.floor((AMOUNT_MINUS_FEES * split.percent) / SPLITS_TOTAL_PERCENT),
             caller.address,
           );
       }),
@@ -913,7 +913,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
               split.lockedUntil,
               split.allocator,
             ],
-            /*payoutAmount*/ Math.floor((AMOUNT_DISTRIBUTED * split.percent) / SPLITS_TOTAL_PERCENT),
+            /*payoutAmount*/ Math.floor((AMOUNT_MINUS_FEES * split.percent) / SPLITS_TOTAL_PERCENT),
             caller.address,
           );
       }),

--- a/test/jb_eth_payment_terminal/toggle_feeless_terminal.test.js
+++ b/test/jb_eth_payment_terminal/toggle_feeless_terminal.test.js
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { deployMockContract } from '@ethereum-waffle/mock-contract';
+
+import jbDirectory from '../../artifacts/contracts/interfaces/IJBDirectory.sol/IJBDirectory.json';
+import JbEthPaymentTerminal from '../../artifacts/contracts/JBETHPaymentTerminal.sol/JBETHPaymentTerminal.json';
+import jbEthPaymentTerminalStore from '../../artifacts/contracts/JBETHPaymentTerminalStore.sol/JBETHPaymentTerminalStore.json';
+import jbOperatoreStore from '../../artifacts/contracts/interfaces/IJBOperatorStore.sol/IJBOperatorStore.json';
+import jbProjects from '../../artifacts/contracts/interfaces/IJBProjects.sol/IJBProjects.json';
+import jbSplitsStore from '../../artifacts/contracts/interfaces/IJBSplitsStore.sol/IJBSplitsStore.json';
+
+describe('JBETHPaymentTerminal::toggleFeelessTerminal(...)', function () {
+  async function setup() {
+    let [deployer, terminalOwner, caller] = await ethers.getSigners();
+
+    let [
+      mockJbDirectory,
+      mockJbEthPaymentTerminal,
+      mockJbEthPaymentTerminalStore,
+      mockJbOperatorStore,
+      mockJbProjects,
+      mockJbSplitsStore,
+    ] = await Promise.all([
+      deployMockContract(deployer, jbDirectory.abi),
+      deployMockContract(deployer, JbEthPaymentTerminal.abi),
+      deployMockContract(deployer, jbEthPaymentTerminalStore.abi),
+      deployMockContract(deployer, jbOperatoreStore.abi),
+      deployMockContract(deployer, jbProjects.abi),
+      deployMockContract(deployer, jbSplitsStore.abi),
+    ]);
+
+    let jbTerminalFactory = await ethers.getContractFactory('JBETHPaymentTerminal', deployer);
+
+    const currentNonce = await ethers.provider.getTransactionCount(deployer.address);
+    const futureTerminalAddress = ethers.utils.getContractAddress({
+      from: deployer.address,
+      nonce: currentNonce + 1,
+    });
+
+    await mockJbEthPaymentTerminalStore.mock.claimFor.withArgs(futureTerminalAddress).returns();
+
+    let jbEthPaymentTerminal = await jbTerminalFactory
+      .connect(deployer)
+      .deploy(
+        mockJbOperatorStore.address,
+        mockJbProjects.address,
+        mockJbDirectory.address,
+        mockJbSplitsStore.address,
+        mockJbEthPaymentTerminalStore.address,
+        terminalOwner.address,
+      );
+
+    return {
+      terminalOwner,
+      caller,
+      jbEthPaymentTerminal,
+      mockJbEthPaymentTerminal,
+    };
+  }
+
+  it('Should add a terminal as feeless and emit event, if the terminal was not feeless before', async function () {
+    const { terminalOwner, jbEthPaymentTerminal, mockJbEthPaymentTerminal } = await setup();
+
+    expect(await jbEthPaymentTerminal.connect(terminalOwner).toggleFeelessTerminal(mockJbEthPaymentTerminal.address))
+      .to.emit(jbEthPaymentTerminal, 'SetFeelessTerminal')
+      .withArgs(mockJbEthPaymentTerminal.address, terminalOwner.address);
+    
+    expect(await jbEthPaymentTerminal.isFeelessTerminal(mockJbEthPaymentTerminal.address)).to.be.true;
+  });
+
+  it('Should remove a terminal as feeless and emit event, if the terminal was feeless before', async function () {
+    const { terminalOwner, jbEthPaymentTerminal, mockJbEthPaymentTerminal } = await setup();
+
+    await jbEthPaymentTerminal.connect(terminalOwner).toggleFeelessTerminal(mockJbEthPaymentTerminal.address);
+
+    expect(await jbEthPaymentTerminal.connect(terminalOwner).toggleFeelessTerminal(mockJbEthPaymentTerminal.address))
+      .to.emit(jbEthPaymentTerminal, 'SetFeelessTerminal')
+      .withArgs(mockJbEthPaymentTerminal.address, terminalOwner.address);
+    
+    expect(await jbEthPaymentTerminal.isFeelessTerminal(mockJbEthPaymentTerminal.address)).to.be.false;
+  });
+});


### PR DESCRIPTION
Payout splits that go to other projects bypass fees.

in other words, only funds leaving the ecosystem incur the fee.