### PR TITLE
feat: increase the fee precision

### DIFF
--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -123,9 +123,9 @@ contract JBETHPaymentTerminal is
     The platform fee percent.
 
     @dev
-    Out of MAX_FEE.
+    Out of MAX_FEE (50_000_000 / 1_000_000_000)
   */
-  uint256 public override fee = 10;
+  uint256 public override fee = 50_000_000; // 5%
 
   /**
     @notice
@@ -734,7 +734,7 @@ contract JBETHPaymentTerminal is
     if (feeAmount == 0) return 0;
 
     _fundingCycle.shouldHoldFees()
-      ? _heldFeesOf[_projectId].push(JBFee(_amount, uint8(fee), _beneficiary))
+      ? _heldFeesOf[_projectId].push(JBFee(_amount, uint32(fee), _beneficiary))
       : _takeFee(feeAmount, _beneficiary); // Take the fee.
   }
 

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -70,7 +70,7 @@ contract JBETHPaymentTerminal is
     @notice
     Maximum fee that can be set for a funding cycle configuration.
   */
-  uint256 private constant _FEE_CAP = 10;
+  uint256 private constant _FEE_CAP = 50_000_000;
 
   //*********************************************************************//
   // --------------------- private stored properties ------------------- //

--- a/contracts/libraries/JBConstants.sol
+++ b/contracts/libraries/JBConstants.sol
@@ -32,9 +32,9 @@ library JBConstants {
 
   /** 
     @notice
-    Maximum fee rate as a percentage out of 200.
+    Maximum fee rate as a percentage out of 1000000000
   */
-  uint256 public constant MAX_FEE = 200;
+  uint256 public constant MAX_FEE = 1000000000;
 
   /** 
     @notice

--- a/contracts/structs/JBFee.sol
+++ b/contracts/structs/JBFee.sol
@@ -5,7 +5,7 @@ struct JBFee {
   // The total amount the fee was taken from.
   uint256 amount;
   // The percent of the fee.
-  uint8 fee;
+  uint32 fee;
   // The address that will receive the tokens that are minted as a result of the fee payment.
   address beneficiary;
 }

--- a/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
+++ b/test/jb_eth_payment_terminal/distribute_payouts_of.test.js
@@ -20,7 +20,7 @@ describe('JBETHPaymentTerminal::distributePayoutsOf(...)', function () {
 
   const AMOUNT_DISTRIBUTED = 1000000000000;
 
-  const DEFAULT_FEE = 10; // 5%
+  const DEFAULT_FEE =   50000000; // 5%
   const FEE_DISCOUNT = 500000000; // 50%
 
   const CURRENCY = 1;

--- a/test/jb_eth_payment_terminal/set_fee.test.js
+++ b/test/jb_eth_payment_terminal/set_fee.test.js
@@ -68,7 +68,7 @@ describe('JBETHPaymentTerminal::setFee(...)', function () {
 
   it("Can't set fee above 5%", async function () {
     const { jbEthPaymentTerminal, terminalOwner } = await setup();
-    await expect(jbEthPaymentTerminal.connect(terminalOwner).setFee(11)) // 5.5%
+    await expect(jbEthPaymentTerminal.connect(terminalOwner).setFee(50_000_001)) // 5.0000001% (out of 1,000,000,000)
       .to.be.revertedWith(errors.FEE_TOO_HIGH);
   });
 });

--- a/test/jb_eth_payment_terminal/use_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal/use_allowance_of.test.js
@@ -14,8 +14,8 @@ import jbSplitsStore from '../../artifacts/contracts/interfaces/IJBSplitsStore.s
 
 describe('JBETHPaymentTerminal::useAllowanceOf(...)', function () {
   const AMOUNT = 50000;
-  const DEFAULT_FEE = 10; // 5%
-  const FEE_DISCOUNT = 500000; // 50%
+  const DEFAULT_FEE =   50000000; // 5%
+  const FEE_DISCOUNT = 500000000; // 50%
 
   const AMOUNT_MINUS_FEES = Math.floor((AMOUNT * 200) / (DEFAULT_FEE + 200));
 

--- a/test/jb_eth_payment_terminal/use_allowance_of.test.js
+++ b/test/jb_eth_payment_terminal/use_allowance_of.test.js
@@ -17,15 +17,15 @@ describe('JBETHPaymentTerminal::useAllowanceOf(...)', function () {
   const DEFAULT_FEE =   50000000; // 5%
   const FEE_DISCOUNT = 500000000; // 50%
 
-  const AMOUNT_MINUS_FEES = Math.floor((AMOUNT * 200) / (DEFAULT_FEE + 200));
-
   const FUNDING_CYCLE_NUM = 1;
   const JUICEBOX_PROJECT_ID = 1;
   const MEMO = 'test memo';
   const PROJECT_ID = 13;
   const WEIGHT = 1000;
 
+  let MAX_FEE;
   let MAX_FEE_DISCOUNT;
+  let AMOUNT_MINUS_FEES;
 
   async function setup() {
     const [deployer, beneficiary, otherCaller, projectOwner, terminalOwner] =
@@ -77,6 +77,9 @@ describe('JBETHPaymentTerminal::useAllowanceOf(...)', function () {
     const jbConstantsFactory = await ethers.getContractFactory('JBConstants');
     const jbConstants = await jbConstantsFactory.deploy();
     MAX_FEE_DISCOUNT = await jbConstants.MAX_FEE_DISCOUNT();
+    MAX_FEE = (await jbConstants.MAX_FEE()).toNumber();
+
+    AMOUNT_MINUS_FEES = Math.floor((AMOUNT * MAX_FEE) / (DEFAULT_FEE + MAX_FEE));
 
     let jbOperationsFactory = await ethers.getContractFactory('JBOperations');
     let jbOperations = await jbOperationsFactory.deploy();
@@ -339,7 +342,7 @@ describe('JBETHPaymentTerminal::useAllowanceOf(...)', function () {
 
     const DISCOUNTED_FEE =
       DEFAULT_FEE - Math.floor((DEFAULT_FEE * FEE_DISCOUNT) / MAX_FEE_DISCOUNT);
-    const AMOUNT_MINUS_DISCOUNTED_FEES = Math.floor((AMOUNT * 200) / (200 + DISCOUNTED_FEE));
+    const AMOUNT_MINUS_DISCOUNTED_FEES = Math.floor((AMOUNT * MAX_FEE) / (MAX_FEE + DISCOUNTED_FEE));
 
     await mockJbFeeGauge.mock.currentDiscountFor.withArgs(PROJECT_ID).returns(FEE_DISCOUNT);
 


### PR DESCRIPTION
Currently, fee are out of 200 (defined as MAX_FEE in JBConstant) -> increase the precision by changing them out of 1 000 000 000, matching the MAX_FEE_DISCOUNT

Test updated + fee now packed in uint32 in JBFee[] -> no change in storage layout, 2 words:
uint256 -> 32b
uint32 -> 4b
address -> 20b