### PR TITLE
mint take useReservedRate bool instead of reservedRate value

### DIFF
--- a/contracts/JBETHPaymentTerminalStore.sol
+++ b/contracts/JBETHPaymentTerminalStore.sol
@@ -304,7 +304,7 @@ contract JBETHPaymentTerminalStore {
           address(uint160(_preferClaimedTokensAndBeneficiary >> 1)),
           '',
           (_preferClaimedTokensAndBeneficiary & 1) == 1,
-          fundingCycle.reservedRate()
+          true
         );
       }
     }
@@ -474,7 +474,7 @@ contract JBETHPaymentTerminalStore {
       ? _amount
       : PRBMathUD60x18.div(_amount, prices.priceFor(_currency, JBCurrencies.ETH));
 
-    // The project balance should be bigger than the amount withdrawn from the overflow 
+    // The project balance should be bigger than the amount withdrawn from the overflow
     if (balanceOf[_projectId] < withdrawnAmount) {
       revert INADEQUATE_PAYMENT_TERMINAL_STORE_BALANCE();
     }

--- a/contracts/interfaces/IJBController.sol
+++ b/contracts/interfaces/IJBController.sol
@@ -19,7 +19,7 @@ interface IJBController {
     address _beneficiary,
     string calldata _memo,
     bool _preferClaimedTokens,
-    uint256 _reserveRate
+    bool _useReservedRate
   ) external returns (uint256 beneficiaryTokenCount);
 
   function burnTokensOf(

--- a/test/jb_eth_payment_terminal_store/record_payment_from.test.js
+++ b/test/jb_eth_payment_terminal_store/record_payment_from.test.js
@@ -108,7 +108,7 @@ describe('JBETHPaymentTerminalStore::recordPaymentFrom(...)', function () {
         /* beneficiary */ beneficiary.address,
         /* memo */ '',
         /* preferClaimedTokens */ false,
-        /* reservedRate */ reservedRate,
+        /* useReservedRate */ true,
       )
       .returns(WEIGHTED_AMOUNT);
 
@@ -194,7 +194,7 @@ describe('JBETHPaymentTerminalStore::recordPaymentFrom(...)', function () {
         /* beneficiary */ beneficiary.address,
         /* memo */ '',
         /* preferClaimedTokens */ false,
-        /* reservedRate */ reservedRate,
+        /* useReservedRate */ true,
       )
       .returns(WEIGHTED_AMOUNT);
 
@@ -474,7 +474,7 @@ describe('JBETHPaymentTerminalStore::recordPaymentFrom(...)', function () {
         /* beneficiary */ beneficiary.address,
         /* memo */ '',
         /* preferClaimedTokens */ false,
-        /* reservedRate */ reservedRate,
+        /* useReservedRate */ true,
       )
       .returns(WEIGHTED_AMOUNT);
 


### PR DESCRIPTION
`mintTokensOf()` takes a `_useReservedRate` bool instead of a `_reservedRate` value. If `_useReservedRate` is `true`, the reserved rate of the current funding cycle is used.

This prevents a potential misexpectation where a project owner could mint tokens using a reserved rate that mismatches the current funding cycle's rate, which