### PR TITLE
allow split with no beneficiary, projectId, or allocator. Direct thes…

### DIFF
--- a/contracts/JBController.sol
+++ b/contracts/JBController.sol
@@ -820,12 +820,14 @@ contract JBController is IJBController, JBOperatable, ReentrancyGuard {
       // Mints tokens for the split if needed.
       if (_tokenCount > 0) {
         tokenStore.mintFor(
-          // If an allocator is set in the splits, set it as the beneficiary. Otherwise if a projectId is set in the split, set the project's owner as the beneficiary. Otherwise use the split's beneficiary.
+          // If an allocator is set in the splits, set it as the beneficiary. Otherwise if a projectId is set in the split, set the project's owner as the beneficiary. If the split has a beneficiary send to the split's beneficiary. Otherwise send to the msg.sender.
           _split.allocator != IJBSplitAllocator(address(0))
             ? address(_split.allocator)
             : _split.projectId != 0
             ? projects.ownerOf(_split.projectId)
-            : _split.beneficiary,
+            : _split.beneficiary != address(0)
+            ? _split.beneficiary
+            : msg.sender,
           _projectId,
           _tokenCount,
           _split.preferClaimed

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -751,18 +751,15 @@ contract JBETHPaymentTerminal is
               bytes('')
             );
           }
-        } else if (_split.beneficiary != address(0)) {
-          // This distribution is eligible for a fee since the funds are leaving the ecosystem.
-          feeEligibleDistributionAmount += _payoutAmount;
-
-          // Otherwise if there's a beneficiary, send the funds directly to the beneficiary.
-          Address.sendValue(_split.beneficiary, _netPayoutAmount);
         } else {
           // This distribution is eligible for a fee since the funds are leaving the ecosystem.
           feeEligibleDistributionAmount += _payoutAmount;
 
-          // Otherwise, send the funds directly to the msg.sender.
-          Address.sendValue(payable(msg.sender), _netPayoutAmount);
+          // If there's a beneficiary, send the funds directly to the beneficiary. Otherwise send to the msg.sender
+          Address.sendValue(
+            _split.beneficiary != address(0) ? _split.beneficiary : payable(msg.sender),
+            _netPayoutAmount
+          );
         }
 
         // Subtract from the amount to be sent to the beneficiary.

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -751,12 +751,18 @@ contract JBETHPaymentTerminal is
               bytes('')
             );
           }
+        } else if (_split.beneficiary != address(0)) {
+          // This distribution is eligible for a fee since the funds are leaving the ecosystem.
+          feeEligibleDistributionAmount += _payoutAmount;
+
+          // Otherwise if there's a beneficiary, send the funds directly to the beneficiary.
+          Address.sendValue(_split.beneficiary, _netPayoutAmount);
         } else {
           // This distribution is eligible for a fee since the funds are leaving the ecosystem.
           feeEligibleDistributionAmount += _payoutAmount;
 
-          // Otherwise, send the funds directly to the beneficiary.
-          Address.sendValue(_split.beneficiary, _netPayoutAmount);
+          // Otherwise, send the funds directly to the msg.sender.
+          Address.sendValue(payable(msg.sender), _netPayoutAmount);
         }
 
         // Subtract from the amount to be sent to the beneficiary.

--- a/contracts/JBSplitsStore.sol
+++ b/contracts/JBSplitsStore.sol
@@ -198,14 +198,6 @@ contract JBSplitsStore is IJBSplitsStore, JBOperatable {
         revert INVALID_PROJECT_ID();
       }
 
-      // The allocator and the beneficiary shouldn't both be the zero address.
-      if (
-        _splits[_i].allocator == IJBSplitAllocator(address(0)) &&
-        _splits[_i].beneficiary == address(0)
-      ) {
-        revert ALLOCATOR_AND_BENEFICIARY_ZERO_ADDRESS();
-      }
-
       // Add to the total percents.
       _percentTotal = _percentTotal + _splits[_i].percent;
 


### PR DESCRIPTION
…e payouts and reserved token splits to msg.sender.

- allows projects to create incentives for someone to click the `distribute` buttons. at least roughly compensate gas.