### PR TITLE
price feed takes decimals as input

### DIFF
--- a/contracts/JBERC20PaymentTerminal.sol
+++ b/contracts/JBERC20PaymentTerminal.sol
@@ -2,14 +2,15 @@
 /* solhint-disable comprehensive-interface*/
 pragma solidity 0.8.6;
 
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 // Inheritance
 import './JBPaymentTerminal.sol';
 
 contract JBERC20PaymentTerminal is JBPaymentTerminal {
   constructor(
-    IERC20 _token,
+    IERC20Metadata _token,
+    uint256 _decimals,
     uint256 _currency,
     uint256 _baseWeightCurrency,
     uint256 _payoutSplitsGroup,
@@ -22,6 +23,7 @@ contract JBERC20PaymentTerminal is JBPaymentTerminal {
   )
     JBPaymentTerminal(
       address(_token),
+      _token.decimals(),
       _currency,
       _baseWeightCurrency,
       _payoutSplitsGroup,
@@ -42,8 +44,8 @@ contract JBERC20PaymentTerminal is JBPaymentTerminal {
     address payable _to,
     uint256 _amount
   ) internal override {
-    _from == address(this) ?
-      IERC20(token).transfer(_from, _amount)
+    _from == address(this)
+      ? IERC20(token).transfer(_from, _amount)
       : IERC20(token).transferFrom(_from, _to, _amount);
   }
 

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -23,6 +23,7 @@ contract JBETHPaymentTerminal is JBPaymentTerminal {
   )
     JBPaymentTerminal(
       JBTokens.ETH,
+      18,
       JBCurrencies.ETH,
       _baseWeightCurrency,
       JBSplitsGroups.ETH_PAYOUT,

--- a/contracts/JBPaymentTerminal.sol
+++ b/contracts/JBPaymentTerminal.sol
@@ -123,6 +123,12 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
 
   /**
     @notice
+    The number of decimals assumed by fixed point amounts throughout the terminal.
+  */
+  uint256 public immutable override decimals;
+
+  /**
+    @notice
     The platform fee percent.
 
     @dev
@@ -224,6 +230,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
 
   /**
     @param _token The token that this terminal manages.
+    @param _decimals The number of decimals assumed by fixed point amounts throughout the terminal.
     @param _currency The currency that this terminal's token adheres to for price feeds.
     @param _baseWeightCurrency The currency to base token issuance on.
     @param _payoutSplitsGroup The group that denotes payout splits from this terminal in the splits store.
@@ -236,6 +243,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
   */
   constructor(
     address _token,
+    uint256 _decimals,
     uint256 _currency,
     uint256 _baseWeightCurrency,
     uint256 _payoutSplitsGroup,
@@ -247,6 +255,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
     address _owner
   ) JBOperatable(_operatorStore) {
     token = _token;
+    decimals = _decimals;
     baseWeightCurrency = _baseWeightCurrency;
     payoutSplitsGroup = _payoutSplitsGroup;
     currency = _currency;
@@ -333,6 +342,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
     (JBFundingCycle memory _fundingCycle, uint256 _distributedAmount) = store.recordDistributionFor(
       _projectId,
       _amount,
+      decimals,
       _currency
     );
 
@@ -433,6 +443,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
     (JBFundingCycle memory _fundingCycle, uint256 _distributedAmount) = store.recordUsedAllowanceOf(
       _projectId,
       _amount,
+      decimals,
       _currency
     );
 
@@ -525,6 +536,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
         _holder,
         _projectId,
         _tokenCount,
+        decimals,
         currency,
         _beneficiary,
         _memo
@@ -948,6 +960,7 @@ abstract contract JBPaymentTerminal is IJBPaymentTerminal, JBOperatable, Ownable
       (_fundingCycle, _weight, _tokenCount, _delegate, _memo) = store.recordPaymentFrom(
         _payer,
         _amount,
+        decimals,
         _projectId,
         _beneficiary,
         _memo

--- a/contracts/JBPrices.sol
+++ b/contracts/JBPrices.sol
@@ -48,12 +48,17 @@ contract JBPrices is IJBPrices, Ownable {
     
     @param _currency The currency to get a price for.
     @param _base The currency to base the price on.
+    @param _decimals The number of decimals the returned fixed point price should include.
     
-    @return The price of the currency in terms of the base, with 18 decimals.
+    @return The price of the currency in terms of the base, as a fixed point number with the specified number of decimals.
   */
-  function priceFor(uint256 _currency, uint256 _base) external view override returns (uint256) {
+  function priceFor(
+    uint256 _currency,
+    uint256 _base,
+    uint256 _decimals
+  ) external view override returns (uint256) {
     // If the currency is the base, return 1 since they are priced the same.
-    if (_currency == _base) return 10**TARGET_DECIMALS;
+    if (_currency == _base) return 10**_decimals;
 
     // Get a reference to the feed.
     IJBPriceFeed _feed = feedFor[_currency][_base];
@@ -62,7 +67,7 @@ contract JBPrices is IJBPrices, Ownable {
     if (_feed == IJBPriceFeed(address(0))) revert PRICE_FEED_NOT_FOUND();
 
     // Get the price.
-    return _feed.getPrice(TARGET_DECIMALS);
+    return _feed.getPrice(_decimals);
   }
 
   //*********************************************************************//

--- a/contracts/interfaces/IJBPrices.sol
+++ b/contracts/interfaces/IJBPrices.sol
@@ -12,7 +12,11 @@ interface IJBPrices {
 
   function feedFor(uint256 _currency, uint256 _base) external returns (IJBPriceFeed);
 
-  function priceFor(uint256 _currency, uint256 _base) external view returns (uint256);
+  function priceFor(
+    uint256 _currency,
+    uint256 _base,
+    uint256 _targetDecimals
+  ) external view returns (uint256);
 
   function addFeedFor(
     uint256 _currency,

--- a/contracts/interfaces/IJBTerminal.sol
+++ b/contracts/interfaces/IJBTerminal.sol
@@ -6,6 +6,8 @@ import './IJBDirectory.sol';
 interface IJBTerminal {
   function token() external view returns (address);
 
+  function decimals() external view returns (uint256);
+
   function currency() external view returns (uint256);
 
   function baseWeightCurrency() external view returns (uint256);

--- a/contracts/structs/JBRedeemParamsData.sol
+++ b/contracts/structs/JBRedeemParamsData.sol
@@ -16,6 +16,8 @@ struct JBRedeemParamsData {
   uint256 redemptionRate;
   // The ballot redemption rate of the funding cycle during which the redemption is being made.
   uint256 ballotRedemptionRate;
+  // TODO
+  uint256 decimals;
   // The currency that the stored balance is expected to be in terms of.
   uint256 currency;
   // The proposed beneficiary of the ETH being claimed by making the redemption.


### PR DESCRIPTION
Potentially important optimization I came across when refining JBPrices docs:

JBPrices no longer has TARGET_DECIMALS. Instead, each request for a price includes the desired decimal fidelity.

Why:

- remove tight coupling to 18 decimal fixed point amounts when converting amounts between different terminal currencies. Opens the door for ERC721 and ERC1155 terminals, with conversion rates between these assets using custom price feeds. 1 Punk == 100 Doodles? sure. 

TBH there are probably other weird complexities when introducing NFT-based terminals (should NFT with tokenId X really be treated the same as the same NFT with tokenId Y? How do fees work?), but at least the reliance on 18 decimals price feeds wont be one of them.

WIP tests and inline docs.