### PR TITLE
tokenStore.claim requires holder permission

### DIFF
--- a/contracts/JBTokenStore.sol
+++ b/contracts/JBTokenStore.sol
@@ -355,7 +355,7 @@ contract JBTokenStore is IJBTokenStore, JBControllerUtility, JBOperatable {
     Claims internally accounted for tokens into a holder's wallet.
 
     @dev
-    Anyone can claim tokens on behalf of a token owner.
+    Only a token holder or an operator can claim its unclaimed tokens.
 
     @param _holder The owner of the tokens being claimed.
     @param _projectId The ID of the project whose tokens are being claimed.
@@ -365,7 +365,7 @@ contract JBTokenStore is IJBTokenStore, JBControllerUtility, JBOperatable {
     address _holder,
     uint256 _projectId,
     uint256 _amount
-  ) external override {
+  ) external override requirePermission(_holder, _projectId, JBOperations.CLAIM) {
     // Get a reference to the project's current token.
     IJBToken _token = tokenOf[_projectId];
 

--- a/contracts/JBTokenStore.sol
+++ b/contracts/JBTokenStore.sol
@@ -355,7 +355,7 @@ contract JBTokenStore is IJBTokenStore, JBControllerUtility, JBOperatable {
     Claims internally accounted for tokens into a holder's wallet.
 
     @dev
-    Only a token holder or an operator can claim its unclaimed tokens.
+    Only a token holder, the owner of the token's project, or an operator specified by the token holder can claim its unclaimed tokens.
 
     @param _holder The owner of the tokens being claimed.
     @param _projectId The ID of the project whose tokens are being claimed.
@@ -365,7 +365,16 @@ contract JBTokenStore is IJBTokenStore, JBControllerUtility, JBOperatable {
     address _holder,
     uint256 _projectId,
     uint256 _amount
-  ) external override requirePermission(_holder, _projectId, JBOperations.CLAIM) {
+  )
+    external
+    override
+    requirePermissionAllowingOverride(
+      _holder,
+      _projectId,
+      JBOperations.CLAIM,
+      msg.sender == projects.ownerOf(_projectId)
+    )
+  {
     // Get a reference to the project's current token.
     IJBToken _token = tokenOf[_projectId];
 

--- a/contracts/libraries/JBOperations.sol
+++ b/contracts/libraries/JBOperations.sol
@@ -12,12 +12,13 @@ library JBOperations {
   uint256 public constant CHANGE_TOKEN = 8;
   uint256 public constant MINT = 9;
   uint256 public constant BURN = 10;
-  uint256 public constant TRANSFER = 11;
-  uint256 public constant REQUIRE_CLAIM = 12;
-  uint256 public constant SET_CONTROLLER = 13;
-  uint256 public constant ADD_TERMINALS = 14;
-  uint256 public constant REMOVE_TERMINAL = 15;
-  uint256 public constant SET_PRIMARY_TERMINAL = 16;
-  uint256 public constant USE_ALLOWANCE = 17;
-  uint256 public constant SET_SPLITS = 18;
+  uint256 public constant CLAIM = 11;
+  uint256 public constant TRANSFER = 12;
+  uint256 public constant REQUIRE_CLAIM = 13;
+  uint256 public constant SET_CONTROLLER = 14;
+  uint256 public constant ADD_TERMINALS = 15;
+  uint256 public constant REMOVE_TERMINAL = 16;
+  uint256 public constant SET_PRIMARY_TERMINAL = 17;
+  uint256 public constant USE_ALLOWANCE = 18;
+  uint256 public constant SET_SPLITS = 19;
 }


### PR DESCRIPTION
TokenStore.claim() can now only be done by the token holder, or by a permitted operator. This is the same permission scheme as V1. 

Before this, anyone could claim tokens for an account. Though this might be convenient at times, I sense it would just cause more confusion. Plus, there might be upside in leaving tokens unclaimed.

tested