### PR TITLE
check for failed configuration after FC with duration of 0

### DIFF
--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -143,6 +143,9 @@ contract JBFundingCycleStore is IJBFundingCycleStore, JBControllerUtility {
     // Get the funding cycle of its base funding cycle, which carries the last approved configuration.
     fundingCycle = _getStructFor(_projectId, fundingCycle.basedOn);
 
+    // There's no queued if the base, which must still be the current, has a duration of 0.
+    if (fundingCycle.duration == 0) return _getStructFor(0, 0);
+
     // Return a mock of the next up funding cycle.
     return _mockFundingCycleBasedOn(fundingCycle, false);
   }
@@ -203,6 +206,9 @@ contract JBFundingCycleStore is IJBFundingCycleStore, JBControllerUtility {
 
     // The funding cycle to base a current one on.
     _fundingCycle = _getStructFor(_projectId, _fundingCycleConfiguration);
+
+    // If the base has no duration, it's still the current one.
+    if (_fundingCycle.duration == 0) return _fundingCycle;
 
     // Return a mock of the current funding cycle.
     return _mockFundingCycleBasedOn(_fundingCycle, true);
@@ -554,6 +560,9 @@ contract JBFundingCycleStore is IJBFundingCycleStore, JBControllerUtility {
     @dev
     Returns an empty funding cycle if there can't be a mock funding cycle based on the provided one.
 
+    @dev
+    Assumes a funding cycle with a duration of 0 will never be asked to be the base of a mock.
+
     @param _baseFundingCycle The funding cycle that the resulting funding cycle should follow.
     @param _allowMidCycle A flag indicating if the mocked funding cycle is allowed to already be mid cycle.
 
@@ -566,8 +575,7 @@ contract JBFundingCycleStore is IJBFundingCycleStore, JBControllerUtility {
   {
     // Get the distance of the current time to the start of the next possible funding cycle.
     // If the returned mock cycle must not yet have started, the start time of the mock must be in the future.
-    // If the base funding cycle doesn't have a duration, no adjustment is necessary because the next cycle can start immediately.
-    uint256 _mustStartAtOrAfter = !_allowMidCycle || _baseFundingCycle.duration == 0
+    uint256 _mustStartAtOrAfter = !_allowMidCycle
       ? block.timestamp + 1
       : block.timestamp - _baseFundingCycle.duration + 1;
 

--- a/test/jb_funding_cycle_store/configure_for.test.js
+++ b/test/jb_funding_cycle_store/configure_for.test.js
@@ -1223,6 +1223,82 @@ describe('JBFundingCycleStore::configureFor(...)', function () {
     });
   });
 
+  it('Should not use a funding cycle that fails a ballot if current funding cycle has 0 duration', async function () {
+    const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore, addrs } = await setup();
+    await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);
+
+    const firstFundingCycleData = createFundingCycleData({ ballot: mockBallot.address, duration: BigNumber.from(0) });
+
+    // Configure first funding cycle
+    const firstConfigureForTx = await jbFundingCycleStore
+      .connect(controller)
+      .configureFor(
+        PROJECT_ID,
+        firstFundingCycleData,
+        RANDOM_FUNDING_CYCLE_METADATA_1,
+        FUNDING_CYCLE_CAN_START_ASAP,
+      );
+
+    // The timestamp the first configuration was made during.
+    const firstConfigurationTimestamp = await getTimestamp(firstConfigureForTx.blockNumber);
+
+    const expectedFirstFundingCycle = {
+      number: ethers.BigNumber.from(1),
+      configuration: firstConfigurationTimestamp,
+      basedOn: ethers.BigNumber.from(0),
+      start: firstConfigurationTimestamp,
+      duration: BigNumber.from(0),
+      weight: firstFundingCycleData.weight,
+      discountRate: firstFundingCycleData.discountRate,
+      ballot: firstFundingCycleData.ballot,
+      metadata: RANDOM_FUNDING_CYCLE_METADATA_1,
+    };
+
+    const secondFundingCycleData = createFundingCycleData({
+      ballot: addrs[0].address,
+      duration: firstFundingCycleData.duration.add(1),
+      discountRate: firstFundingCycleData.discountRate.add(1),
+      weight: firstFundingCycleData.weight.add(1),
+    });
+
+    //fast forward to within the cycle.
+    await fastForward(firstConfigureForTx.blockNumber, BigNumber.from(1));
+
+    // Set the ballot to have a short duration.
+    await mockBallot.mock.duration.withArgs().returns(0);
+
+    // Configure second funding cycle
+    const secondConfigureForTx = await jbFundingCycleStore
+      .connect(controller)
+      .configureFor(
+        PROJECT_ID,
+        secondFundingCycleData,
+        RANDOM_FUNDING_CYCLE_METADATA_2,
+        FUNDING_CYCLE_CAN_START_ASAP,
+      );
+
+    // The timestamp the second configuration was made during.
+    const secondConfigurationTimestamp = await getTimestamp(secondConfigureForTx.blockNumber);
+
+    // Set the ballot to be failed for the upcoming reconfig.
+    await mockBallot.mock.stateOf
+      .withArgs(PROJECT_ID, secondConfigurationTimestamp)
+      .returns(ballotStatus.FAILED);
+
+    // Ballot status should be failed.
+    expect(await jbFundingCycleStore.currentBallotStateOf(PROJECT_ID)).to.eql(2);
+
+    await expect(secondConfigureForTx)
+      .to.emit(jbFundingCycleStore, `Init`)
+      .withArgs(secondConfigurationTimestamp, PROJECT_ID, /*basedOn=*/ firstConfigurationTimestamp);
+
+    expect(cleanFundingCycle(await jbFundingCycleStore.currentOf(PROJECT_ID))).to.eql(
+      expectedFirstFundingCycle,
+    );
+    // The reconfiguration should not have taken effect.
+    expect(cleanFundingCycle(await jbFundingCycleStore.queuedOf(PROJECT_ID))).to.eql(EMPTY_FUNDING_CYCLE);
+  });
+
   it("Should hold off on using a reconfigured funding cycle if the current cycle's ballot duration doesn't end until after the current cycle is over", async function () {
     const { controller, mockJbDirectory, mockBallot, jbFundingCycleStore, addrs } = await setup();
     await mockJbDirectory.mock.controllerOf.withArgs(PROJECT_ID).returns(controller.address);


### PR DESCRIPTION
A funding cycle of duration 0 should never be asked to have a mock based on it.

Added a test that was failing before the contract changes.