### PR TITLE
PoC for genesis NFT datasource + delegate

### DIFF
--- a/contracts/NFT/JBGenesisNFTDataSource.sol
+++ b/contracts/NFT/JBGenesisNFTDataSource.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import './../interfaces/IJBPayDelegate.sol';
+import './../structs/JBPayParamsData.sol';
+import './../structs/JBRedeemParamsData.sol';
+
+contract JBGenesisNFTDataSource is IJBFundingCycleDataSource {
+  IJBPayDelegate public immutable payDelegate;
+
+  constructor(IJBPayDelegate _payDelegate) {
+    payDelegate = _payDelegate;
+  }
+
+  function payParams(JBPayParamsData calldata _data)
+    external
+    view
+    override
+    returns (
+      uint256 weight,
+      string memory memo,
+      IJBPayDelegate delegate
+    ) {
+      weight = _data.weight;
+      memo = _data.memo;
+      delegate = payDelegate;
+    }
+
+  function redeemParams(JBRedeemParamsData calldata _data)
+    external
+    pure
+    override
+    returns (
+      uint256 reclaimAmount,
+      string memory memo,
+      IJBRedemptionDelegate delegate
+    )
+    // solhint-disable-next-line no-empty-blocks
+    { }
+}

--- a/contracts/NFT/JBGenesisNFTPayDelegate.sol
+++ b/contracts/NFT/JBGenesisNFTPayDelegate.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import './../interfaces/IJBPayDelegate.sol';
+import './../structs/JBDidPayData.sol';
+
+contract JBGenesisNFTPayDelegate is IJBPayDelegate {
+  // IJBGenesisNFT public immutable genesisNft;
+
+  // constructor (IJBGenesisNFT _genesisNFT) {
+  //   genesisNFT = _genesisNFT;
+  // }
+
+  function didPay(JBDidPayData calldata _data) override external {
+    // TODO: call mint from NFT contract
+    // _data.amount contains pay amount
+  }
+}


### PR DESCRIPTION
Make use of a custom datasource and custom pay delegate to integrate genesis NFTs. The payment terminal will know to eventually call the NFT contract at the end of the pay() function.

During project setup, the flow probably looks like this:

1) Deploy a genesis NFT contract (TBD)
2) Deploy custom pay delegate which points to 1
3) Deploy custom data source which points to 2
4) Add data source and flip on the "useDataSourceForPay" switch in the fundingCycleMetadata