### PR TITLE
Smol: change minting access control in controller

### DIFF
--- a/contracts/JBController.sol
+++ b/contracts/JBController.sol
@@ -655,12 +655,9 @@ contract JBController is IJBController, IJBMigratable, JBOperatable, ERC165 {
       );
 
       // If the message sender is not a terminal or a datasource, the current funding cycle must allow minting.
-      if (
-        !_fundingCycle.mintingAllowed()
-        && (
-          !directory.isTerminalOf(_projectId, IJBPaymentTerminal(msg.sender))
-          && msg.sender != address(_fundingCycle.dataSource())
-        )
+      if ( !_fundingCycle.mintingAllowed()
+        && !directory.isTerminalOf(_projectId, IJBPaymentTerminal(msg.sender))
+        && msg.sender != address(_fundingCycle.dataSource())
       ) revert MINT_NOT_ALLOWED_AND_NOT_TERMINAL_DELEGATE();
 
       // Determine the reserved rate to use.

--- a/test/jb_controller/mint_tokens_of.test.js
+++ b/test/jb_controller/mint_tokens_of.test.js
@@ -30,7 +30,7 @@ describe('JBController::mintTokensOf(...)', function () {
   });
 
   async function setup() {
-    let [deployer, projectOwner, beneficiary, ...addrs] = await ethers.getSigners();
+    let [deployer, projectOwner, beneficiary, mockDatasource, ...addrs] = await ethers.getSigners();
 
     const blockNum = await ethers.provider.getBlockNumber();
     const block = await ethers.provider.getBlock(blockNum);
@@ -92,6 +92,7 @@ describe('JBController::mintTokensOf(...)', function () {
     return {
       projectOwner,
       beneficiary,
+      mockDatasource,
       addrs,
       jbController,
       mockJbOperatorStore,
@@ -216,6 +217,67 @@ describe('JBController::mintTokensOf(...)', function () {
         MEMO,
         RESERVED_RATE,
         terminalSigner.address,
+      );
+
+    let newReservedTokenBalance = await jbController.reservedTokenBalanceOf(
+      PROJECT_ID,
+      RESERVED_RATE,
+    );
+    expect(newReservedTokenBalance).to.equal(AMOUNT_TO_MINT - AMOUNT_TO_RECEIVE);
+  });
+
+  it(`Should mint token if caller is the current funding cycle's datasource of the corresponding project`, async function () {
+    const { projectOwner, beneficiary, mockDatasource, jbController, mockJbFundingCycleStore, mockJbOperatorStore, mockJbDirectory, timestamp } =
+      await setup();
+    const terminal = await deployMockContract(projectOwner, jbTerminal.abi);
+    const terminalSigner = await impersonateAccount(terminal.address);
+
+    await mockJbOperatorStore.mock.hasPermission
+      .withArgs(terminalSigner.address, projectOwner.address, PROJECT_ID, MINT_INDEX)
+      .returns(false);
+
+    await mockJbOperatorStore.mock.hasPermission
+      .withArgs(terminalSigner.address, projectOwner.address, 0, MINT_INDEX)
+      .returns(false);
+
+    await mockJbDirectory.mock.isTerminalOf
+      .withArgs(PROJECT_ID, terminalSigner.address)
+      .returns(false);
+
+    await mockJbFundingCycleStore.mock.currentOf.withArgs(PROJECT_ID).returns({
+      // mock JBFundingCycle obj
+      number: 1,
+      configuration: timestamp,
+      basedOn: timestamp,
+      start: timestamp,
+      duration: 0,
+      weight: 0,
+      discountRate: 0,
+      ballot: ethers.constants.AddressZero,
+      metadata: packFundingCycleMetadata({ allowMinting: 1, reservedRate: RESERVED_RATE, dataSource: mockDatasource.address }),
+    });
+
+    await expect(
+      jbController
+        .connect(mockDatasource)
+        .mintTokensOf(
+          PROJECT_ID,
+          AMOUNT_TO_MINT,
+          beneficiary.address,
+          MEMO,
+          /*_preferClaimedTokens=*/ true,
+          /* _useReservedRate=*/ true,
+        ),
+    )
+      .to.emit(jbController, 'MintTokens')
+      .withArgs(
+        beneficiary.address,
+        PROJECT_ID,
+        AMOUNT_TO_MINT,
+        AMOUNT_TO_RECEIVE,
+        MEMO,
+        RESERVED_RATE,
+        mockDatasource.address,
       );
 
     let newReservedTokenBalance = await jbController.reservedTokenBalanceOf(

--- a/test/jb_controller/mint_tokens_of.test.js
+++ b/test/jb_controller/mint_tokens_of.test.js
@@ -241,7 +241,7 @@ describe('JBController::mintTokensOf(...)', function () {
       .returns(false);
 
     await mockJbDirectory.mock.isTerminalOf
-      .withArgs(PROJECT_ID, terminalSigner.address)
+      .withArgs(PROJECT_ID, mockDatasource.address)
       .returns(false);
 
     await mockJbFundingCycleStore.mock.currentOf.withArgs(PROJECT_ID).returns({
@@ -334,7 +334,7 @@ describe('JBController::mintTokensOf(...)', function () {
     ).to.be.revertedWith(errors.ZERO_TOKENS_TO_MINT);
   });
 
-  it(`Can't mint token if funding cycle is paused and caller is not a terminal delegate`, async function () {
+  it(`Can't mint token if funding cycle is paused and caller is not a terminal delegate or a datasource`, async function () {
     const { projectOwner, beneficiary, jbController, mockJbFundingCycleStore, timestamp } =
       await setup();
 


### PR DESCRIPTION
Allows the current funding cycle's datasource to mint without being part of the authorized domain