### PR TITLE
added param

### DIFF
--- a/contracts/JBETHERC20SplitsPayer.sol
+++ b/contracts/JBETHERC20SplitsPayer.sol
@@ -151,7 +151,7 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       JBTokens.ETH,
       address(this).balance,
       18, // decimals.
-      msg.sender
+      defaultBeneficiary != address(0) ? defaultBeneficiary : msg.sender
     );
 
     // If there is no leftover amount, nothing left to pay.
@@ -268,7 +268,7 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       _token,
       _amount,
       _decimals,
-      msg.sender
+      defaultBeneficiary != address(0) ? defaultBeneficiary : msg.sender
     );
 
     // Pay any leftover amount.
@@ -360,7 +360,7 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       _token,
       _amount,
       _decimals,
-      msg.sender
+      defaultBeneficiary != address(0) ? defaultBeneficiary : msg.sender
     );
 
     // Distribute any leftover amount.

--- a/contracts/JBETHERC20SplitsPayer.sol
+++ b/contracts/JBETHERC20SplitsPayer.sol
@@ -150,7 +150,8 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       defaultSplitsGroup,
       JBTokens.ETH,
       address(this).balance,
-      18 // decimals.
+      18, // decimals.
+      msg.sender
     );
 
     // If there is no leftover amount, nothing left to pay.
@@ -266,7 +267,8 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       defaultSplitsGroup,
       _token,
       _amount,
-      _decimals
+      _decimals,
+      msg.sender
     );
 
     // Pay any leftover amount.
@@ -357,7 +359,8 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
       defaultSplitsGroup,
       _token,
       _amount,
-      _decimals
+      _decimals,
+      msg.sender
     );
 
     // Distribute any leftover amount.
@@ -413,6 +416,7 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
     @param _token The token the amonut being split is in.
     @param _amount The amount of tokens being split, as a fixed point number. If the `_token` is ETH, this is ignored and msg.value is used in its place.
     @param _decimals The number of decimals in the `_amount` fixed point number. 
+    @param _defaultBeneficiary The address that will benefit from any non-specified beneficiaries in splits.
 
     @return leftoverAmount The amount leftover after all splits were paid.
   */
@@ -422,7 +426,8 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
     uint256 _splitsGroup,
     address _token,
     uint256 _amount,
-    uint256 _decimals
+    uint256 _decimals,
+    address _defaultBeneficiary
   ) internal virtual returns (uint256 leftoverAmount) {
     // Get a reference to the splits.
     JBSplit[] memory _splits = splitsStore.splitsOf(_splitsProjectId, _splitsDomain, _splitsGroup);
@@ -483,7 +488,7 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
               _token,
               _splitAmount,
               _decimals,
-              _split.beneficiary != address(0) ? _split.beneficiary : msg.sender,
+              _split.beneficiary != address(0) ? _split.beneficiary : _defaultBeneficiary,
               0,
               _split.preferClaimed,
               defaultMemo,
@@ -494,14 +499,14 @@ contract JBETHERC20SplitsPayer is IJBSplitsPayer, JBETHERC20ProjectPayer, Reentr
           if (_token == JBTokens.ETH)
             Address.sendValue(
               // Get a reference to the address receiving the tokens. If there's a beneficiary, send the funds directly to the beneficiary. Otherwise send to the msg.sender.
-              _split.beneficiary != address(0) ? _split.beneficiary : payable(msg.sender),
+              _split.beneficiary != address(0) ? _split.beneficiary : payable(_defaultBeneficiary),
               _splitAmount
             );
             // Or, transfer the ERC20.
           else {
             IERC20(_token).transfer(
               // Get a reference to the address receiving the tokens. If there's a beneficiary, send the funds directly to the beneficiary. Otherwise send to the msg.sender.
-              _split.beneficiary != address(0) ? _split.beneficiary : msg.sender,
+              _split.beneficiary != address(0) ? _split.beneficiary : _defaultBeneficiary,
               _splitAmount
             );
           }

--- a/test/jb_eth_erc20_splits_payer/add_to_balance.test.js
+++ b/test/jb_eth_erc20_splits_payer/add_to_balance.test.js
@@ -17,7 +17,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   const DEFAULT_SPLITS_DOMAIN = 1;
   const DEFAULT_SPLITS_GROUP = 1;
   const DECIMALS = 18;
-  const DEFAULT_BENEFICIARY = ethers.Wallet.createRandom().address;
+  let DEFAULT_BENEFICIARY;
   const DEFAULT_PREFER_CLAIMED_TOKENS = false;
   const DEFAULT_MEMO = 'hello world';
   const DEFAULT_METADATA = '0x42';
@@ -47,8 +47,10 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
   });
 
   async function setup() {
-    let [deployer, owner, caller, beneficiaryOne, beneficiaryTwo, beneficiaryThree, ...addrs] =
+    let [deployer, owner, caller, beneficiaryOne, beneficiaryTwo, beneficiaryThree, defaultBeneficiarySigner, ...addrs] =
       await ethers.getSigners();
+
+    DEFAULT_BENEFICIARY = defaultBeneficiarySigner.address;
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
@@ -77,6 +79,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
       beneficiaryOne,
       beneficiaryTwo,
       beneficiaryThree,
+      defaultBeneficiarySigner,
       deployer,
       caller,
       owner,
@@ -397,7 +400,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
     );
   });
 
-  it(`Should send fund towards project terminal if project ID is set in split, using pay with the caller as beneficiary if none is set in splits and emit event`, async function () {
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with the default beneficiary if none is set in splits and emit event`, async function () {
     const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
       await setup();
 
@@ -416,7 +419,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
             split.projectId,
             AMOUNT.mul(split.percent).div(maxSplitsPercent),
             ethToken,
-            caller.address,
+            DEFAULT_BENEFICIARY,
             0 /*hardcoded*/,
             split.preferClaimed,
             DEFAULT_MEMO,
@@ -537,8 +540,8 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
     );
   });
 
-  it(`Should send fund directly to the caller, if no allocator, project ID or beneficiary is set,  and emit event`, async function () {
-    const { caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+  it(`Should send fund directly to the default beneficiary, if no allocator, project ID or beneficiary is set,  and emit event`, async function () {
+    const { caller, jbSplitsPayer, mockJbSplitsStore, defaultBeneficiarySigner } = await setup();
 
     let splits = makeSplits();
 
@@ -552,7 +555,7 @@ describe('JBETHERC20SplitsPayer::addToBalanceOf(...)', function () {
         value: AMOUNT,
       });
 
-    await expect(tx).to.changeEtherBalance(caller, 0); // Send then receive the amount (gas is not taken into account)
+    await expect(tx).to.changeEtherBalance(defaultBeneficiarySigner, AMOUNT); // Send then receive the amount (gas is not taken into account)
 
     await expect(tx).to.emit(jbSplitsPayer, 'AddToBalance').withArgs(
       PROJECT_ID,

--- a/test/jb_eth_erc20_splits_payer/pay.test.js
+++ b/test/jb_eth_erc20_splits_payer/pay.test.js
@@ -17,7 +17,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   const DEFAULT_SPLITS_DOMAIN = 1;
   const DEFAULT_SPLITS_GROUP = 1;
   const DECIMALS = 18;
-  const DEFAULT_BENEFICIARY = ethers.Wallet.createRandom().address;
+  let DEFAULT_BENEFICIARY;
   const DEFAULT_PREFER_CLAIMED_TOKENS = false;
   const DEFAULT_MEMO = 'hello world';
   const DEFAULT_METADATA = '0x42';
@@ -47,8 +47,10 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   });
 
   async function setup() {
-    let [deployer, owner, caller, beneficiaryOne, beneficiaryTwo, beneficiaryThree, ...addrs] =
+    let [deployer, owner, caller, beneficiaryOne, beneficiaryTwo, beneficiaryThree, defaultBeneficiarySigner, ...addrs] =
       await ethers.getSigners();
+
+    DEFAULT_BENEFICIARY = defaultBeneficiarySigner.address;
 
     let mockJbDirectory = await deployMockContract(deployer, jbDirectory.abi);
     let mockJbSplitsStore = await deployMockContract(deployer, jbSplitsStore.abi);
@@ -77,6 +79,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
       beneficiaryOne,
       beneficiaryTwo,
       beneficiaryThree,
+      defaultBeneficiarySigner,
       deployer,
       caller,
       owner,
@@ -397,7 +400,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
     );
   });
 
-  it(`Should send fund towards project terminal if project ID is set in split, using pay with the caller as beneficiary is none is set in splits and emit event`, async function () {
+  it(`Should send fund towards project terminal if project ID is set in split, using pay with the default beneficiary if none is set in splits and emit event`, async function () {
     const { caller, jbSplitsPayer, mockJbSplitsStore, mockJbDirectory, mockJbTerminal } =
       await setup();
 
@@ -416,7 +419,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
             split.projectId,
             AMOUNT.mul(split.percent).div(maxSplitsPercent),
             ethToken,
-            caller.address,
+            DEFAULT_BENEFICIARY,
             0 /*hardcoded*/,
             split.preferClaimed,
             DEFAULT_MEMO,
@@ -562,7 +565,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
   });
 
   it(`Should send fund directly to the caller, if no allocator, project ID or beneficiary is set and emit event`, async function () {
-    const { caller, jbSplitsPayer, mockJbSplitsStore } = await setup();
+    const { caller, jbSplitsPayer, mockJbSplitsStore, defaultBeneficiarySigner } = await setup();
 
     let splits = makeSplits();
 
@@ -587,7 +590,7 @@ describe('JBETHERC20SplitsPayer::pay(...)', function () {
         },
       );
 
-    await expect(tx).to.changeEtherBalance(caller, 0); // Send then receive the amount (gas is not taken into account)
+    await expect(tx).to.changeEtherBalance(defaultBeneficiarySigner, AMOUNT);
     await expect(tx).to.emit(jbSplitsPayer, 'Pay').withArgs(
       PROJECT_ID,
       DEFAULT_BENEFICIARY,


### PR DESCRIPTION
Added a param in internal fn for inheriters to specify where to send tokens if not specified in splits.

Useful for JBMarket here https://github.com/jbx-protocol/juice-market/blob/9fa048c3f0ddacc81de7a60ee04dc3cf27a14a30/contracts/JBMarket.sol#L406

needs tests @drgorillamd 