### PR TITLE
fixed

### DIFF
--- a/contracts/JBFundingCycleStore.sol
+++ b/contracts/JBFundingCycleStore.sol
@@ -387,8 +387,8 @@ contract JBFundingCycleStore is IJBFundingCycleStore, JBControllerUtility {
     // Get a reference to the funding cycle.
     JBFundingCycle memory _baseFundingCycle = _getStructFor(_projectId, _currentConfiguration);
 
-    if (!_isApproved(_projectId, _baseFundingCycle))
-      // If it hasn't been approved, set the ID to be the funding cycle it's based on,
+    if (!_isApproved(_projectId, _baseFundingCycle) || block.timestamp < _baseFundingCycle.start)
+      // If it hasn't been approved or hasn't yet started, set the ID to be the funding cycle it's based on,
       // which carries the latest approved configuration.
       _baseFundingCycle = _getStructFor(_projectId, _baseFundingCycle.basedOn);
 

--- a/contracts/system_tests/TestReconfigure.sol
+++ b/contracts/system_tests/TestReconfigure.sol
@@ -187,13 +187,21 @@ contract TestReconfigureProject is TestBaseWorkflow {
     );
     uint256 secondReconfiguration = block.timestamp;
 
-    // Shouldn't have changed, still in FC#2 rolled over
+    // Shouldn't have changed, still in FC#2, rolled over from FC#1
     fundingCycle = jbFundingCycleStore().currentOf(projectId);
     assertEq(fundingCycle.number, 2);
     assertEq(fundingCycle.configuration, currentConfiguration);
     assertEq(fundingCycle.weight, _data.weight);
 
-    // Jump to the next one
+    // Jump to after the ballot passed, but before the next FC
+    evm.warp(fundingCycle.start + fundingCycle.duration - 1);
+
+    // Queued should be the second reconfiguration
+    JBFundingCycle memory queuedFundingCycle = jbFundingCycleStore().queuedOf(projectId);
+    assertEq(queuedFundingCycle.number, 3);
+    assertEq(queuedFundingCycle.configuration, secondReconfiguration);
+    assertEq(queuedFundingCycle.weight, weightSecondReconfiguration);
+
     evm.warp(fundingCycle.start + fundingCycle.duration);
 
     // Second reconfiguration should be now the current one

--- a/test/jb_funding_cycle_store/configure_for.test.js
+++ b/test/jb_funding_cycle_store/configure_for.test.js
@@ -2335,7 +2335,7 @@ describe('JBFundingCycleStore::configureFor(...)', function () {
       weight: firstFundingCycleData.weight.add(2),
     });
 
-    // Configure second funding cycle
+    // Configure third funding cycle
     const thirdConfigureForTx = await jbFundingCycleStore
       .connect(controller)
       .configureFor(


### PR DESCRIPTION
Fixes a bug in the protocol that causes the wrong funding cycle to appear as "current".

Steps to reproduce the bug:

1. configure an fc (FC#N) with a duration.
2. let the fc rollover to another fc (FC#N+1). this step is necessary.
3. send a tx to reconfigure the next fc (FC#N+2) before FC#N+1 expires.
4. send another tx to reconfigure the next fc (FC#N+2) before FC#N+1 expires.

See the conversation here: https://discord.com/channels/775859454780244028/876252266594721873/978706407085977670