### PR TITLE
payDelegate can now receive funds directly from the terminal

### DIFF
--- a/contracts/JBChainlinkV3PriceFeed.sol
+++ b/contracts/JBChainlinkV3PriceFeed.sol
@@ -13,7 +13,7 @@ import './libraries/JBFixedPointNumber.sol';
   Adheres to -
   IJBPriceFeed: General interface for the methods in this contract that interact with the blockchain's state according to the protocol's rules.
 */
-contract JBChainlinkV3PriceFeed is IJBPriceFeed {
+contract JBChainlinkV3PriceFeedV2_1 is IJBPriceFeed {
   // A library that provides utility for fixed point numbers.
   using JBFixedPointNumber for uint256;
 

--- a/contracts/JBERC20PaymentTerminal.sol
+++ b/contracts/JBERC20PaymentTerminal.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.6;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import './abstract/JBPayoutRedemptionPaymentTerminal.sol';
 
 /** 
@@ -17,6 +18,21 @@ import './abstract/JBPayoutRedemptionPaymentTerminal.sol';
   JBPayoutRedemptionPaymentTerminal: Includes convenience functionality for checking a message sender's permissions before executing certain transactions.
 */
 contract JBERC20PaymentTerminal is JBPayoutRedemptionPaymentTerminal {
+  using SafeERC20 for IERC20;
+
+  //*********************************************************************//
+  // -------------------------- internal views ------------------------- //
+  //*********************************************************************//
+
+  /** 
+    @notice
+    Checks the balance of tokens in this contract.
+    @return The contract's balance.
+  */
+  function _balance() internal view override returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+
   //*********************************************************************//
   // -------------------------- constructor ---------------------------- //
   //*********************************************************************//
@@ -84,8 +100,8 @@ contract JBERC20PaymentTerminal is JBPayoutRedemptionPaymentTerminal {
     uint256 _amount
   ) internal override {
     _from == address(this)
-      ? IERC20(token).transfer(_to, _amount)
-      : IERC20(token).transferFrom(_from, _to, _amount);
+      ? IERC20(token).safeTransfer(_to, _amount)
+      : IERC20(token).safeTransferFrom(_from, _to, _amount);
   }
 
   /** 

--- a/contracts/JBERC20PaymentTerminal.sol
+++ b/contracts/JBERC20PaymentTerminal.sol
@@ -17,7 +17,7 @@ import './abstract/JBPayoutRedemptionPaymentTerminal.sol';
   Inherits from -
   JBPayoutRedemptionPaymentTerminal: Includes convenience functionality for checking a message sender's permissions before executing certain transactions.
 */
-contract JBERC20PaymentTerminal is JBPayoutRedemptionPaymentTerminal {
+contract JBERC20PaymentTerminalV2_1 is JBPayoutRedemptionPaymentTerminalV2_1 {
   using SafeERC20 for IERC20;
 
   //*********************************************************************//
@@ -60,10 +60,10 @@ contract JBERC20PaymentTerminal is JBPayoutRedemptionPaymentTerminal {
     IJBDirectory _directory,
     IJBSplitsStore _splitsStore,
     IJBPrices _prices,
-    IJBSingleTokenPaymentTerminalStore _store,
+    IJBSingleTokenPaymentTerminalStoreV2_1 _store,
     address _owner
   )
-    JBPayoutRedemptionPaymentTerminal(
+    JBPayoutRedemptionPaymentTerminalV2_1(
       address(_token),
       _token.decimals(),
       _currency,

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -14,6 +14,19 @@ import './abstract/JBPayoutRedemptionPaymentTerminal.sol';
 */
 contract JBETHPaymentTerminal is JBPayoutRedemptionPaymentTerminal {
   //*********************************************************************//
+  // -------------------------- internal views ------------------------- //
+  //*********************************************************************//
+
+  /** 
+    @notice
+    Checks the balance of tokens in this contract.
+    @return The contract's balance.
+  */
+  function _balance() internal view override returns (uint256) {
+    return address(this).balance;
+  }
+
+  //*********************************************************************//
   // -------------------------- constructor ---------------------------- //
   //*********************************************************************//
 
@@ -76,17 +89,5 @@ contract JBETHPaymentTerminal is JBPayoutRedemptionPaymentTerminal {
     _from; // Prevents unused var compiler and natspec complaints.
 
     Address.sendValue(_to, _amount);
-  }
-
-  /** 
-    @notice
-    Logic to be triggered before transferring tokens from this terminal.
-
-    @param _to The address to which the transfer is going.
-    @param _amount The amount of the transfer, as a fixed point number with the same number of decimals as this terminal.
-  */
-  function _beforeTransferTo(address _to, uint256 _amount) internal pure override {
-    _to; // Prevents unused var compiler and natspec complaints.
-    _amount; // Prevents unused var compiler and natspec complaints.
   }
 }

--- a/contracts/JBETHPaymentTerminal.sol
+++ b/contracts/JBETHPaymentTerminal.sol
@@ -12,7 +12,7 @@ import './abstract/JBPayoutRedemptionPaymentTerminal.sol';
   Inherits from -
   JBPayoutRedemptionPaymentTerminal: Generic terminal managing all inflows and outflows of funds into the protocol ecosystem.
 */
-contract JBETHPaymentTerminal is JBPayoutRedemptionPaymentTerminal {
+contract JBETHPaymentTerminalV2_1 is JBPayoutRedemptionPaymentTerminalV2_1 {
   //*********************************************************************//
   // -------------------------- internal views ------------------------- //
   //*********************************************************************//
@@ -47,10 +47,10 @@ contract JBETHPaymentTerminal is JBPayoutRedemptionPaymentTerminal {
     IJBDirectory _directory,
     IJBSplitsStore _splitsStore,
     IJBPrices _prices,
-    IJBSingleTokenPaymentTerminalStore _store,
+    IJBSingleTokenPaymentTerminalStoreV2_1 _store,
     address _owner
   )
-    JBPayoutRedemptionPaymentTerminal(
+    JBPayoutRedemptionPaymentTerminalV2_1(
       JBTokens.ETH,
       18, // 18 decimals.
       JBCurrencies.ETH,

--- a/contracts/JBPrices.sol
+++ b/contracts/JBPrices.sol
@@ -17,7 +17,7 @@ import './interfaces/IJBPrices.sol';
   Inherits from -
   Ownable: Includes convenience functionality for checking a message sender's permissions before executing certain transactions.
 */
-contract JBPrices is IJBPrices, Ownable {
+contract JBPricesV2_1 is IJBPrices, Ownable {
   //*********************************************************************//
   // --------------------------- custom errors ------------------------- //
   //*********************************************************************//

--- a/contracts/JBPrices.sol
+++ b/contracts/JBPrices.sol
@@ -112,7 +112,10 @@ contract JBPrices is IJBPrices, Ownable {
     IJBPriceFeed _feed
   ) external override onlyOwner {
     // There can't already be a feed for the specified currency.
-    if (feedFor[_currency][_base] != IJBPriceFeed(address(0))) revert PRICE_FEED_ALREADY_EXISTS();
+    if (
+      feedFor[_currency][_base] != IJBPriceFeed(address(0)) ||
+      feedFor[_base][_currency] != IJBPriceFeed(address(0))
+    ) revert PRICE_FEED_ALREADY_EXISTS();
 
     // Store the feed.
     feedFor[_currency][_base] = _feed;

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -294,7 +294,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     Records newly contributed tokens to a project.
 
     @dev
-    Mint's the project's tokens according to values provided by a configured data source. If no data source is configured, mints tokens proportional to the amount of the contribution.
+    Mints the project's tokens according to values provided by a configured data source. If no data source is configured, mints tokens proportional to the amount of the contribution.
 
     @dev
     The msg.sender must be an IJBSingleTokenPaymentTerminal. The amount specified in the params is in terms of the msg.sender's tokens.

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -29,7 +29,9 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
   //*********************************************************************//
   // --------------------------- custom errors ------------------------- //
   //*********************************************************************//
+  error INVALID_AMOUNT_TO_SEND_DELEGATE();
   error CURRENCY_MISMATCH();
+  error DELEGATE_NOT_SPECIFIED();
   error DISTRIBUTION_AMOUNT_LIMIT_REACHED();
   error FUNDING_CYCLE_PAYMENT_PAUSED();
   error FUNDING_CYCLE_DISTRIBUTION_PAUSED();
@@ -287,6 +289,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
   // ---------------------- external transactions ---------------------- //
   //*********************************************************************//
 
+
   /**
     @notice
     Records newly contributed tokens to a project.
@@ -305,10 +308,8 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     @param _memo A memo to pass along to the emitted event, and passed along to the funding cycle's data source.
     @param _metadata Bytes to send along to the data source, if one is provided.
 
-    @return fundingCycle The project's funding cycle during which payment was made.
-    @return tokenCount The number of project tokens that were minted, as a fixed point number with 18 decimals.
-    @return delegate A delegate contract to use for subsequent calls.
-    @return memo A memo that should be passed along to the emitted event.
+    @return response todo 
+ 
   */
   function recordPaymentFrom(
     address _payer,
@@ -322,60 +323,61 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     external
     override
     nonReentrant
-    returns (
-      JBFundingCycle memory fundingCycle,
-      uint256 tokenCount,
-      IJBPayDelegate delegate,
-      string memory memo
-    )
+    returns (JBDidRecordPaymentResponse memory response)
   {
     // Get a reference to the current funding cycle for the project.
-    fundingCycle = fundingCycleStore.currentOf(_projectId);
+    response.fundingCycle = fundingCycleStore.currentOf(_projectId);
 
     // The project must have a funding cycle configured.
-    if (fundingCycle.number == 0) revert INVALID_FUNDING_CYCLE();
+    if (response.fundingCycle.number == 0) revert INVALID_FUNDING_CYCLE();
 
     // Must not be paused.
-    if (fundingCycle.payPaused()) revert FUNDING_CYCLE_PAYMENT_PAUSED();
+    if (response.fundingCycle.payPaused()) revert FUNDING_CYCLE_PAYMENT_PAUSED();
 
     // The weight according to which new token supply is to be minted, as a fixed point number with 18 decimals.
     uint256 _weight;
 
     // If the funding cycle has configured a data source, use it to derive a weight and memo.
-    if (fundingCycle.useDataSourceForPay()) {
+    if (response.fundingCycle.useDataSourceForPay()) {
       // Create the params that'll be sent to the data source.
       JBPayParamsData memory _data = JBPayParamsData(
         IJBSingleTokenPaymentTerminal(msg.sender),
         _payer,
         _amount,
         _projectId,
-        fundingCycle.configuration,
+        response.fundingCycle.configuration,
         _beneficiary,
-        fundingCycle.weight,
-        fundingCycle.reservedRate(),
+        response.fundingCycle.weight,
+        response.fundingCycle.reservedRate(),
         _memo,
         _metadata
       );
-      (_weight, memo, delegate) = IJBFundingCycleDataSource(fundingCycle.dataSource()).payParams(
+      (_weight, response.memo, response.delegate, response.delegatedAmount) = IJBFundingCycleDataSource(response.fundingCycle.dataSource()).payParams(
         _data
       );
+      
+      // Can't delegate an amount if there's no delegate.
+      if (response.delegatedAmount > 0 && response.delegate == IJBPayDelegate(address(0))) revert DELEGATE_NOT_SPECIFIED();
+
+      // Can't delegate more than was paid.
+      if (response.delegatedAmount > _amount.value) revert INVALID_AMOUNT_TO_SEND_DELEGATE();
     }
     // Otherwise use the funding cycle's weight
     else {
-      _weight = fundingCycle.weight;
-      memo = _memo;
+      _weight = response.fundingCycle.weight;
+      response.memo = _memo;
     }
-
+    
     // If there's no amount being recorded, there's nothing left to do.
-    if (_amount.value == 0) return (fundingCycle, 0, delegate, memo);
+    if (_amount.value == 0) return response;
 
-    // Add the amount to the token balance of the project.
+    // Add the amount to the token balance of the project. Don't add the amount that will be delegated.
     balanceOf[IJBSingleTokenPaymentTerminal(msg.sender)][_projectId] =
       balanceOf[IJBSingleTokenPaymentTerminal(msg.sender)][_projectId] +
-      _amount.value;
+      _amount.value - response.delegatedAmount;
 
     // If there's no weight, token count must be 0 so there's nothing left to do.
-    if (_weight == 0) return (fundingCycle, 0, delegate, memo);
+    if (_weight == 0) return response;
 
     // Get a reference to the number of decimals in the amount. (prevents stack too deep).
     uint256 _decimals = _amount.decimals;
@@ -387,7 +389,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
       : prices.priceFor(_amount.currency, _baseWeightCurrency, _decimals);
 
     // Find the number of tokens to mint, as a fixed point number with as many decimals as `weight` has.
-    tokenCount = PRBMath.mulDiv(_amount.value, _weight, _weightRatio);
+    response.tokenCount = PRBMath.mulDiv(_amount.value, _weight, _weightRatio);
   }
 
   /**

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -517,8 +517,9 @@ contract JBSingleTokenPaymentTerminalStoreV2_1 is
           _currentOverflow,
           _reclaimedTokenAmount,
           fundingCycle.useTotalOverflowForRedemptions(),
-          fundingCycle.redemptionRate(),
-          fundingCycle.ballotRedemptionRate(),
+          fundingCycleStore.currentBallotStateOf(_projectId) == JBBallotState.Active
+            ? fundingCycle.ballotRedemptionRate()
+            : fundingCycle.redemptionRate(),
           _memo,
           _metadata
         );

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -22,7 +22,10 @@ import './libraries/JBFundingCycleMetadataResolver.sol';
   Inherits from -
   ReentrancyGuard: Contract module that helps prevent reentrant calls to a function.
 */
-contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore, ReentrancyGuard {
+contract JBSingleTokenPaymentTerminalStoreV2_1 is
+  IJBSingleTokenPaymentTerminalStoreV2_1,
+  ReentrancyGuard
+{
   // A library that parses the packed funding cycle metadata into a friendlier format.
   using JBFundingCycleMetadataResolver for JBFundingCycle;
 

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -308,7 +308,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     @param _memo A memo to pass along to the emitted event, and passed along to the funding cycle's data source.
     @param _metadata Bytes to send along to the data source, if one is provided.
 
-    @return response todo 
+    @return response Contextual data to return.  
  
   */
   function recordPaymentFrom(
@@ -323,7 +323,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     external
     override
     nonReentrant
-    returns (JBDidRecordPaymentResponse memory response)
+    returns (JBRecordPaymentResponse memory response)
   {
     // Get a reference to the current funding cycle for the project.
     response.fundingCycle = fundingCycleStore.currentOf(_projectId);

--- a/contracts/JBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/JBSingleTokenPaymentTerminalStore.sol
@@ -424,7 +424,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
 
     @return fundingCycle The funding cycle during which the redemption was made.
     @return reclaimAmount The amount of terminal tokens reclaimed, as a fixed point number with 18 decimals.
-    @return delegate A delegate contract to use for subsequent calls.
+    @return delegates Delegate contracts to use for subsequent calls.
     @return memo A memo that should be passed along to the emitted event.
   */
   function recordRedemptionFor(
@@ -440,7 +440,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
     returns (
       JBFundingCycle memory fundingCycle,
       uint256 reclaimAmount,
-      IJBRedemptionDelegate delegate,
+      IJBRedemptionDelegate[] memory delegates,
       string memory memo
     )
   {
@@ -519,7 +519,7 @@ contract JBSingleTokenPaymentTerminalStore is IJBSingleTokenPaymentTerminalStore
           _memo,
           _metadata
         );
-        (reclaimAmount, memo, delegate) = IJBFundingCycleDataSource(fundingCycle.dataSource())
+        (reclaimAmount, memo, delegates) = IJBFundingCycleDataSource(fundingCycle.dataSource())
           .redeemParams(_data);
       } else {
         memo = _memo;

--- a/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
@@ -34,7 +34,7 @@ import './JBSingleTokenPaymentTerminal.sol';
   JBOperatable: Includes convenience functionality for checking a message sender's permissions before executing certain transactions.
   Ownable: Includes convenience functionality for checking a message sender's permissions before executing certain transactions.
 */
-abstract contract JBPayoutRedemptionPaymentTerminal is
+abstract contract JBPayoutRedemptionPaymentTerminalV2_1 is
   JBSingleTokenPaymentTerminal,
   JBOperatable,
   Ownable,
@@ -133,7 +133,7 @@ abstract contract JBPayoutRedemptionPaymentTerminal is
     @notice
     The contract that stores and manages the terminal's data.
   */
-  IJBSingleTokenPaymentTerminalStore public immutable override store;
+  IJBSingleTokenPaymentTerminalStoreV2_1 public immutable override store;
 
   /**
     @notice
@@ -292,7 +292,7 @@ abstract contract JBPayoutRedemptionPaymentTerminal is
     IJBDirectory _directory,
     IJBSplitsStore _splitsStore,
     IJBPrices _prices,
-    IJBSingleTokenPaymentTerminalStore _store,
+    IJBSingleTokenPaymentTerminalStoreV2_1 _store,
     address _owner
   )
     payable

--- a/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
@@ -1272,7 +1272,7 @@ abstract contract JBPayoutRedemptionPaymentTerminal is
 
     // Define variables that will be needed outside the scoped section below.
     // Keep a reference to the response from recording the payment.
-    JBDidRecordPaymentResponse memory _response;
+    JBRecordPaymentResponse memory _response;
 
     // Scoped section prevents stack too deep. `_delegate` and `_tokenCount` only used within scope.
     {

--- a/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/abstract/JBPayoutRedemptionPaymentTerminal.sol
@@ -1313,7 +1313,6 @@ abstract contract JBPayoutRedemptionPaymentTerminalV2_1 is
     // Scoped section prevents stack too deep. `_delegates` and `_tokenCount` only used within scope.
     {
       IJBPayDelegate[] memory _delegates;
-      uint256 _tokenCount;
 
       // Bundle the amount info into a JBTokenAmount struct.
       JBTokenAmount memory _bundledAmount = JBTokenAmount(token, _amount, decimals, currency);

--- a/contracts/interfaces/IJBFundingCycleDataSource.sol
+++ b/contracts/interfaces/IJBFundingCycleDataSource.sol
@@ -14,8 +14,8 @@ interface IJBFundingCycleDataSource is IERC165 {
     returns (
       uint256 weight,
       string memory memo,
-      IJBPayDelegate delegate,
-      uint256 delegatedAmount
+      IJBPayDelegate[] memory delegate,
+      uint256[] memory delegatedAmount
     );
 
   function redeemParams(JBRedeemParamsData calldata _data)

--- a/contracts/interfaces/IJBFundingCycleDataSource.sol
+++ b/contracts/interfaces/IJBFundingCycleDataSource.sol
@@ -14,7 +14,8 @@ interface IJBFundingCycleDataSource is IERC165 {
     returns (
       uint256 weight,
       string memory memo,
-      IJBPayDelegate delegate
+      IJBPayDelegate delegate,
+      uint256 delegatedAmount
     );
 
   function redeemParams(JBRedeemParamsData calldata _data)

--- a/contracts/interfaces/IJBFundingCycleDataSource.sol
+++ b/contracts/interfaces/IJBFundingCycleDataSource.sol
@@ -14,8 +14,8 @@ interface IJBFundingCycleDataSource is IERC165 {
     returns (
       uint256 weight,
       string memory memo,
-      IJBPayDelegate[] memory delegate,
-      uint256[] memory delegatedAmount
+      IJBPayDelegate[] memory delegates,
+      uint256[] memory delegatedAmounts
     );
 
   function redeemParams(JBRedeemParamsData calldata _data)
@@ -23,6 +23,6 @@ interface IJBFundingCycleDataSource is IERC165 {
     returns (
       uint256 reclaimAmount,
       string memory memo,
-      IJBRedemptionDelegate delegate
+      IJBRedemptionDelegate[] memory delegates
     );
 }

--- a/contracts/interfaces/IJBPayDelegate.sol
+++ b/contracts/interfaces/IJBPayDelegate.sol
@@ -5,5 +5,5 @@ import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBDidPayData.sol';
 
 interface IJBPayDelegate is IERC165 {
-  function didPay(JBDidPayData calldata _data) external;
+  function didPay(JBDidPayData calldata _data) payable external;
 }

--- a/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
@@ -102,7 +102,12 @@ interface IJBPayoutRedemptionPaymentTerminal is
     address caller
   );
 
-  event DelegateDidPay(IJBPayDelegate indexed delegate, JBDidPayData data, uint256 delegatedAmount, address caller);
+  event DelegateDidPay(
+    IJBPayDelegate indexed delegate,
+    JBDidPayData data,
+    uint256 delegatedAmount,
+    address caller
+  );
 
   event RedeemTokens(
     uint256 indexed fundingCycleConfiguration,
@@ -146,7 +151,7 @@ interface IJBPayoutRedemptionPaymentTerminal is
 
   function prices() external view returns (IJBPrices);
 
-  function store() external view returns (IJBSingleTokenPaymentTerminalStore);
+  function store() external view returns (IJBSingleTokenPaymentTerminalStoreV2_1);
 
   function baseWeightCurrency() external view returns (uint256);
 

--- a/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
@@ -102,7 +102,7 @@ interface IJBPayoutRedemptionPaymentTerminal is
     address caller
   );
 
-  event DelegateDidPay(IJBPayDelegate indexed delegate, JBDidPayData data, address caller);
+  event DelegateDidPay(IJBPayDelegate indexed delegate, JBDidPayData data, uint256 delegatedAmount, address caller);
 
   event RedeemTokens(
     uint256 indexed fundingCycleConfiguration,

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
@@ -70,7 +70,7 @@ interface IJBSingleTokenPaymentTerminalStore {
     bytes calldata _metadata
   )
     external
-    returns (JBDidRecordPaymentResponse memory response);
+    returns (JBRecordPaymentResponse memory response);
 
   function recordRedemptionFor(
     address _holder,

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.6;
 
 import './../structs/JBFundingCycle.sol';
 import './../structs/JBTokenAmount.sol';
+import './../structs/JBRecordPaymentResponse.sol';
 import './IJBDirectory.sol';
 import './IJBFundingCycleStore.sol';
 import './IJBPayDelegate.sol';
@@ -69,12 +70,7 @@ interface IJBSingleTokenPaymentTerminalStore {
     bytes calldata _metadata
   )
     external
-    returns (
-      JBFundingCycle memory fundingCycle,
-      uint256 tokenCount,
-      IJBPayDelegate delegate,
-      string memory memo
-    );
+    returns (JBDidRecordPaymentResponse memory response);
 
   function recordRedemptionFor(
     address _holder,

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
@@ -68,9 +68,7 @@ interface IJBSingleTokenPaymentTerminalStore {
     address _beneficiary,
     string calldata _memo,
     bytes calldata _metadata
-  )
-    external
-    returns (JBRecordPaymentResponse memory response);
+  ) external returns (JBRecordPaymentResponse memory response);
 
   function recordRedemptionFor(
     address _holder,
@@ -83,7 +81,7 @@ interface IJBSingleTokenPaymentTerminalStore {
     returns (
       JBFundingCycle memory fundingCycle,
       uint256 reclaimAmount,
-      IJBRedemptionDelegate delegate,
+      IJBRedemptionDelegate[] memory delegate,
       string memory memo
     );
 

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
@@ -11,7 +11,7 @@ import './IJBPrices.sol';
 import './IJBRedemptionDelegate.sol';
 import './IJBSingleTokenPaymentTerminal.sol';
 
-interface IJBSingleTokenPaymentTerminalStore {
+interface IJBSingleTokenPaymentTerminalStoreV2_1 {
   function fundingCycleStore() external view returns (IJBFundingCycleStore);
 
   function directory() external view returns (IJBDirectory);

--- a/contracts/structs/JBRecordPaymentResponse.sol
+++ b/contracts/structs/JBRecordPaymentResponse.sol
@@ -11,7 +11,7 @@ import '../interfaces/IJBPayDelegate.sol';
  @member delegatedAmount The amount to send to the delegate instead of adding to the local balance.
  @member memo A memo that should be passed along to the emitted event.
 */
-struct JBDidRecordPaymentResponse {
+struct JBRecordPaymentResponse {
   JBFundingCycle fundingCycle;
   uint256 tokenCount;
   IJBPayDelegate delegate;

--- a/contracts/structs/JBRecordPaymentResponse.sol
+++ b/contracts/structs/JBRecordPaymentResponse.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.6;
+
+import './JBFundingCycle.sol';
+import '../interfaces/IJBPayDelegate.sol';
+
+/** 
+ @member fundingCycle The project's funding cycle during which payment was made.
+ @member tokenCount The number of project tokens that were minted, as a fixed point number with 18 decimals.
+ @member delegate A delegate contract to use for subsequent calls.
+ @member delegatedAmount The amount to send to the delegate instead of adding to the local balance.
+ @member memo A memo that should be passed along to the emitted event.
+*/
+struct JBDidRecordPaymentResponse {
+  JBFundingCycle fundingCycle;
+  uint256 tokenCount;
+  IJBPayDelegate delegate;
+  uint256 delegatedAmount;
+  string memo;
+}

--- a/contracts/structs/JBRecordPaymentResponse.sol
+++ b/contracts/structs/JBRecordPaymentResponse.sol
@@ -8,13 +8,13 @@ import '../interfaces/IJBPayDelegate.sol';
  @member fundingCycle The project's funding cycle during which payment was made.
  @member tokenCount The number of project tokens that were minted, as a fixed point number with 18 decimals.
  @member delegate A delegate contract to use for subsequent calls.
- @member delegatedAmount The amount to send to the delegate instead of adding to the local balance.
+ @member delegatedAmounts The amount to send to the delegate instead of adding to the local balance.
  @member memo A memo that should be passed along to the emitted event.
 */
 struct JBRecordPaymentResponse {
   JBFundingCycle fundingCycle;
   uint256 tokenCount;
-  IJBPayDelegate delegate;
-  uint256 delegatedAmount;
+  IJBPayDelegate[] delegates;
+  uint256[] delegatedAmounts;
   string memo;
 }

--- a/contracts/structs/JBRedeemParamsData.sol
+++ b/contracts/structs/JBRedeemParamsData.sol
@@ -15,7 +15,6 @@ import './JBTokenAmount.sol';
   @member reclaimAmount The amount that should be reclaimed by the redeemer using the protocol's standard bonding curve redemption formula. Includes the token being reclaimed, the reclaim value, the number of decimals included, and the currency of the reclaim amount.
   @member useTotalOverflow If overflow across all of a project's terminals is being used when making redemptions.
   @member redemptionRate The redemption rate of the funding cycle during which the redemption is being made.
-  @member ballotRedemptionRate The ballot redemption rate of the funding cycle during which the redemption is being made.
   @member memo The proposed memo that is being emitted alongside the redemption.
   @member metadata Extra data provided by the redeemer.
 */
@@ -30,7 +29,6 @@ struct JBRedeemParamsData {
   JBTokenAmount reclaimAmount;
   bool useTotalOverflow;
   uint256 redemptionRate;
-  uint256 ballotRedemptionRate;
   string memo;
   bytes metadata;
 }

--- a/contracts/system_tests/TestAllowance.sol
+++ b/contracts/system_tests/TestAllowance.sol
@@ -61,7 +61,7 @@ contract TestAllowance is TestBaseWorkflow {
   }
 
   function testAllowance() public {
-    JBETHPaymentTerminal terminal = jbETHPaymentTerminal();
+    JBETHPaymentTerminalV2_1 terminal = jbETHPaymentTerminal();
 
     _fundAccessConstraints.push(
       JBFundAccessConstraints({
@@ -167,7 +167,7 @@ contract TestAllowance is TestBaseWorkflow {
 
     uint256 CURRENCY = jbLibraries().ETH(); // Avoid testing revert on this call...
 
-    JBETHPaymentTerminal terminal = jbETHPaymentTerminal();
+    JBETHPaymentTerminalV2_1 terminal = jbETHPaymentTerminal();
 
     _fundAccessConstraints.push(
       JBFundAccessConstraints({

--- a/contracts/system_tests/TestDistributeHeldFee.sol
+++ b/contracts/system_tests/TestDistributeHeldFee.sol
@@ -8,7 +8,7 @@ import './helpers/TestBaseWorkflow.sol';
 
 contract TestDistributeHeldFee is TestBaseWorkflow {
   JBController private _controller;
-  JBETHPaymentTerminal private _terminal;
+  JBETHPaymentTerminalV2_1 private _terminal;
   JBTokenStore private _tokenStore;
 
   JBProjectMetadata private _projectMetadata;

--- a/contracts/system_tests/TestEIP165.sol
+++ b/contracts/system_tests/TestEIP165.sol
@@ -33,7 +33,7 @@ contract TestEIP165 is TestBaseWorkflow {
   }
 
   function testJBERC20PaymentTerminal() public {
-    JBERC20PaymentTerminal terminal = new JBERC20PaymentTerminal(
+    JBERC20PaymentTerminalV2_1 terminal = new JBERC20PaymentTerminalV2_1(
       jbToken(),
       jbLibraries().USD(), // currency
       jbLibraries().ETH(), // base weight currency
@@ -62,7 +62,7 @@ contract TestEIP165 is TestBaseWorkflow {
   }
 
   function testJBETHPaymentTerminal() public {
-    JBETHPaymentTerminal terminal = jbETHPaymentTerminal();
+    JBETHPaymentTerminalV2_1 terminal = jbETHPaymentTerminal();
 
     // Should support these interfaces
     assertTrue(terminal.supportsInterface(type(IERC165).interfaceId));

--- a/contracts/system_tests/TestERC20Terminal.sol
+++ b/contracts/system_tests/TestERC20Terminal.sol
@@ -58,7 +58,7 @@ contract TestERC20Terminal is TestBaseWorkflow {
   }
 
   function testAllowanceERC20() public {
-    JBERC20PaymentTerminal terminal = jbERC20PaymentTerminal();
+    JBERC20PaymentTerminalV2_1 terminal = jbERC20PaymentTerminal();
 
     _fundAccessConstraints.push(
       JBFundAccessConstraints({
@@ -169,7 +169,7 @@ contract TestERC20Terminal is TestBaseWorkflow {
   ) public {
     evm.assume(jbToken().totalSupply() >= BALANCE);
 
-    JBERC20PaymentTerminal terminal = jbERC20PaymentTerminal();
+    JBERC20PaymentTerminalV2_1 terminal = jbERC20PaymentTerminal();
 
     _fundAccessConstraints.push(
       JBFundAccessConstraints({

--- a/contracts/system_tests/TestMultipleTerminals.sol
+++ b/contracts/system_tests/TestMultipleTerminals.sol
@@ -15,8 +15,8 @@ contract TestMultipleTerminals is TestBaseWorkflow {
   JBFundAccessConstraints[] _fundAccessConstraints;
 
   IJBPaymentTerminal[] _terminals;
-  JBERC20PaymentTerminal ERC20terminal;
-  JBETHPaymentTerminal ETHterminal;
+  JBERC20PaymentTerminalV2_1 ERC20terminal;
+  JBETHPaymentTerminalV2_1 ETHterminal;
 
   JBTokenStore _tokenStore;
   address _projectOwner;
@@ -80,7 +80,7 @@ contract TestMultipleTerminals is TestBaseWorkflow {
       dataSource: address(0)
     });
 
-    ERC20terminal = new JBERC20PaymentTerminal(
+    ERC20terminal = new JBERC20PaymentTerminalV2_1(
       jbToken(),
       jbLibraries().USD(), // currency
       jbLibraries().ETH(), // base weight currency

--- a/contracts/system_tests/TestPayBurnRedeemFlow.sol
+++ b/contracts/system_tests/TestPayBurnRedeemFlow.sol
@@ -12,7 +12,7 @@ import './helpers/TestBaseWorkflow.sol';
  */
 contract TestPayBurnRedeemFlow is TestBaseWorkflow {
   JBController private _controller;
-  JBETHPaymentTerminal private _terminal;
+  JBETHPaymentTerminalV2_1 private _terminal;
   JBTokenStore private _tokenStore;
 
   JBProjectMetadata private _projectMetadata;

--- a/contracts/system_tests/helpers/TestBaseWorkflow.sol
+++ b/contracts/system_tests/helpers/TestBaseWorkflow.sol
@@ -59,7 +59,7 @@ contract TestBaseWorkflow is DSTest {
   // JBProjects
   JBProjects private _jbProjects;
   // JBPrices
-  JBPrices private _jbPrices;
+  JBPricesV2_1 private _jbPrices;
   // JBDirectory
   JBDirectory private _jbDirectory;
   // JBFundingCycleStore
@@ -73,11 +73,11 @@ contract TestBaseWorkflow is DSTest {
   // JBController
   JBController private _jbController;
   // JBETHPaymentTerminalStore
-  JBSingleTokenPaymentTerminalStore private _jbPaymentTerminalStore;
+  JBSingleTokenPaymentTerminalStoreV2_1 private _jbPaymentTerminalStore;
   // JBETHPaymentTerminal
-  JBETHPaymentTerminal private _jbETHPaymentTerminal;
+  JBETHPaymentTerminalV2_1 private _jbETHPaymentTerminal;
   // JBERC20PaymentTerminal
-  JBERC20PaymentTerminal private _jbERC20PaymentTerminal;
+  JBERC20PaymentTerminalV2_1 private _jbERC20PaymentTerminal;
   // AccessJBLib
   AccessJBLib private _accessJBLib;
 
@@ -101,7 +101,7 @@ contract TestBaseWorkflow is DSTest {
     return _jbProjects;
   }
 
-  function jbPrices() internal view returns (JBPrices) {
+  function jbPrices() internal view returns (JBPricesV2_1) {
     return _jbPrices;
   }
 
@@ -125,15 +125,15 @@ contract TestBaseWorkflow is DSTest {
     return _jbController;
   }
 
-  function jbPaymentTerminalStore() internal view returns (JBSingleTokenPaymentTerminalStore) {
+  function jbPaymentTerminalStore() internal view returns (JBSingleTokenPaymentTerminalStoreV2_1) {
     return _jbPaymentTerminalStore;
   }
 
-  function jbETHPaymentTerminal() internal view returns (JBETHPaymentTerminal) {
+  function jbETHPaymentTerminal() internal view returns (JBETHPaymentTerminalV2_1) {
     return _jbETHPaymentTerminal;
   }
 
-  function jbERC20PaymentTerminal() internal view returns (JBERC20PaymentTerminal) {
+  function jbERC20PaymentTerminal() internal view returns (JBERC20PaymentTerminalV2_1) {
     return _jbERC20PaymentTerminal;
   }
 
@@ -164,7 +164,7 @@ contract TestBaseWorkflow is DSTest {
     evm.label(address(_jbProjects), 'JBProjects');
 
     // JBPrices
-    _jbPrices = new JBPrices(_multisig);
+    _jbPrices = new JBPricesV2_1(_multisig);
     evm.label(address(_jbPrices), 'JBPrices');
 
     address contractAtNoncePlusOne = addressFrom(address(this), 5);
@@ -200,7 +200,7 @@ contract TestBaseWorkflow is DSTest {
     _jbDirectory.setIsAllowedToSetFirstController(address(_jbController), true);
 
     // JBETHPaymentTerminalStore
-    _jbPaymentTerminalStore = new JBSingleTokenPaymentTerminalStore(
+    _jbPaymentTerminalStore = new JBSingleTokenPaymentTerminalStoreV2_1(
       _jbDirectory,
       _jbFundingCycleStore,
       _jbPrices
@@ -211,7 +211,7 @@ contract TestBaseWorkflow is DSTest {
     _accessJBLib = new AccessJBLib();
 
     // JBETHPaymentTerminal
-    _jbETHPaymentTerminal = new JBETHPaymentTerminal(
+    _jbETHPaymentTerminal = new JBETHPaymentTerminalV2_1(
       _accessJBLib.ETH(),
       _jbOperatorStore,
       _jbProjects,
@@ -230,7 +230,7 @@ contract TestBaseWorkflow is DSTest {
     _jbToken.mint(0, _multisig, 100 * 10**18);
 
     // JBERC20PaymentTerminal
-    _jbERC20PaymentTerminal = new JBERC20PaymentTerminal(
+    _jbERC20PaymentTerminal = new JBERC20PaymentTerminalV2_1(
       _jbToken,
       _accessJBLib.ETH(), // currency
       _accessJBLib.ETH(), // base weight currency

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -65,7 +65,7 @@ module.exports = {
       optimizer: {
         enabled: true,
         // https://docs.soliditylang.org/en/v0.8.10/internals/optimizer.html#:~:text=Optimizer%20Parameter%20Runs,-The%20number%20of&text=A%20%E2%80%9Cruns%E2%80%9D%20parameter%20of%20%E2%80%9C,is%202**32%2D1%20.
-        runs: 1000000,
+        runs: 10000,
       },
     },
   },


### PR DESCRIPTION
in progress. 

Proposed diff for a v2.1 terminal that projects can migrate to.

No bug fixes, only features:

- PayDelegate is payable, data sources can specify how much of the paid amount should be sent to the pay delegate from the terminal. 

These changes shouldn't land on main. they should be separated into its own repo. Looking at the diff here is useful to see if its worth doing.