### PR TITLE
forge test reconf for short cycles/long ballots

### DIFF
--- a/contracts/system_tests/TestReconfigure.sol
+++ b/contracts/system_tests/TestReconfigure.sol
@@ -585,8 +585,8 @@ contract TestReconfigureProject is TestBaseWorkflow {
     assertEq(fundingCycle.number, 1);
     assertEq(fundingCycle.weight, _data.weight);
 
-    // Should have changed
-    evm.warp(fundingCycle.start + fundingCycle.duration); // Avoid overwriting if same timestamp
+    // Should have changed after the current funding cycle is over
+    evm.warp(fundingCycle.start + fundingCycle.duration);
     fundingCycle = jbFundingCycleStore().currentOf(projectId);
     assertEq(fundingCycle.number, 2);
     assertEq(fundingCycle.weight, _dataReconfiguration.weight);

--- a/contracts/system_tests/TestReconfigure.sol
+++ b/contracts/system_tests/TestReconfigure.sol
@@ -469,4 +469,74 @@ contract TestReconfigureProject is TestBaseWorkflow {
       ''
     );
   }
+
+  function testReconfigureShortDurationProject() public {
+    _data = JBFundingCycleData({
+      duration: 5 minutes,
+      weight: 10000 * 10**18,
+      discountRate: 0,
+      ballot: _ballot
+    });
+
+    _dataReconfiguration = JBFundingCycleData({
+      duration: 6 days,
+      weight: 69 * 10**18,
+      discountRate: 0,
+      ballot: IJBFundingCycleBallot(address(0))
+    });
+
+    uint256 projectId = controller.launchProjectFor(
+      multisig(),
+      _projectMetadata,
+      _data,
+      _metadata,
+      0, // Start asap
+      _groupedSplits,
+      _fundAccessConstraints,
+      _terminals,
+      ''
+    );
+
+    JBFundingCycle memory fundingCycle = jbFundingCycleStore().currentOf(projectId);
+
+    assertEq(fundingCycle.number, 1); // ok
+    assertEq(fundingCycle.weight, _data.weight);
+    emit log_uint(fundingCycle.basedOn);
+    emit log_uint(fundingCycle.configuration);
+
+    uint256 currentConfiguration = fundingCycle.configuration;
+
+    evm.warp(block.timestamp + 1); // Avoid overwriting if same timestamp
+
+    evm.prank(multisig());
+    controller.reconfigureFundingCyclesOf(
+      projectId,
+      _dataReconfiguration,
+      _metadata,
+      0, // Start asap
+      _groupedSplits,
+      _fundAccessConstraints,
+      ''
+    );
+
+    // Shouldn't have changed (same cycle, with a ballot)
+    fundingCycle = jbFundingCycleStore().currentOf(projectId);
+    assertEq(fundingCycle.number, 1);
+    assertEq(fundingCycle.configuration, currentConfiguration);
+    assertEq(fundingCycle.weight, _data.weight);
+
+    // shouldn't have changed (new cycle but ballot is still active)
+    evm.warp(fundingCycle.start + fundingCycle.duration);
+
+    JBFundingCycle memory newFundingCycle = jbFundingCycleStore().currentOf(projectId);
+    assertEq(newFundingCycle.number, 2);
+    assertEq(newFundingCycle.weight, _data.weight);
+
+    // should now be the reconfiguration (ballot duration is over)
+    evm.warp(fundingCycle.start + fundingCycle.duration + 3 days);
+
+    newFundingCycle = jbFundingCycleStore().currentOf(projectId);
+    assertEq(newFundingCycle.number, fundingCycle.number + (3 days / 5 minutes) + 1);
+    assertEq(newFundingCycle.weight, _dataReconfiguration.weight);
+  }
 }


### PR DESCRIPTION
Added some tests, rather for completion, to the system_test>reconfigure:
- ballot longer than the funding cycle duration (expect: reconfiguration taken into account at next fc starts after ballot duration)
- no ballot at all (expect: reconfiguration starting next fc - nit, but wasn't covered)