### PR TITLE
Removed the array and loops for held fees

### DIFF
--- a/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
@@ -157,7 +157,7 @@ interface IJBPayoutRedemptionPaymentTerminal is
 
   function payoutSplitsGroup() external view returns (uint256);
 
-  function heldFeesOf(uint256 _projectId) external view returns (JBFee[] memory);
+  function heldFeesOf(uint256 _projectId) external view returns (JBFee memory);
 
   function fee() external view returns (uint256);
 

--- a/contracts/structs/JBFee.sol
+++ b/contracts/structs/JBFee.sol
@@ -9,7 +9,5 @@ pragma solidity ^0.8.16;
 */
 struct JBFee {
   uint256 amount;
-  uint32 fee;
-  uint32 feeDiscount;
-  address beneficiary;
+  uint256 feeAmount;
 }

--- a/contracts/system_tests/TestDistributeHeldFee.sol
+++ b/contracts/system_tests/TestDistributeHeldFee.sol
@@ -151,9 +151,8 @@ contract TestDistributeHeldFee is TestBaseWorkflow {
 
     // verify: should have held the fee
     if (fee > 0 && payAmountInWei > 0) {
-      assertEq(_terminal.heldFeesOf(_projectId)[0].fee, _terminal.fee());
-      assertEq(_terminal.heldFeesOf(_projectId)[0].feeDiscount, feeDiscount);
-      assertEq(_terminal.heldFeesOf(_projectId)[0].amount, payAmountInWei);
+      // TODO: Add feeAmount check
+      assertEq(_terminal.heldFeesOf(_projectId).amount, payAmountInWei);
     }
 
     // -- add to balance --


### PR DESCRIPTION
Was working on fixing the `_feeAmount` rounding bug, happened to spot that the `_refundHeldFees` and `_processFee` loops might not be necessary, so I ended up doing this.

All tests are still passing and there is a pretty good gas savings. The `beneficiary` is no longer stored, however afaik it could only ever be the address of the owner of the project (also if you transferred a project then the old owner would still be the beneficiary, that is not the case here). 

Making a new pull request for this, as im not sure if this follows the intended behavior of the terminal/heldFees.

```
testFuzzAllowance(uint232,uint232,uint96) (gas: 0 (0.000%)) 
testJBController() (gas: 0 (0.000%)) 
testJBETHERC20SplitsPayer() (gas: 0 (0.000%)) 
testJBETHPaymentTerminal() (gas: 0 (0.000%)) 
testJBProjects() (gas: 0 (0.000%)) 
testJBReconfigurationBufferBallot() (gas: 0 (0.000%)) 
testFuzzedAllowanceERC20(uint232,uint232,uint96) (gas: 0 (0.000%)) 
testLaunchProject() (gas: 0 (0.000%)) 
testLaunchProjectFuzzWeight(uint256) (gas: 0 (0.000%)) 
testFuzzPayBurnRedeemFlow(bool,bool,uint96,uint256,uint256) (gas: 0 (0.000%)) 
testLaunchProjectWrongBallot() (gas: 0 (0.000%)) 
testMultipleReconfigurationOnRolledOver() (gas: 0 (0.000%)) 
testMultipleReconfigure(uint8) (gas: 0 (0.000%)) 
testReconfigureProject() (gas: 0 (0.000%)) 
testReconfigureProjectFuzzRates(uint96,uint96,uint96) (gas: 0 (0.000%)) 
testReconfigureShortDurationProject() (gas: 0 (0.000%)) 
testReconfigureWithoutBallot() (gas: 0 (0.000%)) 
testFuzzTokenFlow(uint224,uint256,bool,bool,bool) (gas: 0 (0.000%)) 
testLargeTokenClaimFlow() (gas: 0 (0.000%)) 
testAllowanceERC20() (gas: -12 (-0.001%)) 
testAllowance() (gas: -12 (-0.001%)) 
testMultipleTerminal() (gas: -12 (-0.001%)) 
testHeldFeeReimburse(uint256,uint16,uint256) (gas: -4522 (-1.291%)) 
testJBERC20PaymentTerminal() (gas: -284345 (-6.477%)) 
Overall gas change: -288903 (-7.772%)
```