### PR TITLE
fix: solc ^0.8.0 in non-logic contracts

### DIFF
--- a/contracts/enums/JBBallotState.sol
+++ b/contracts/enums/JBBallotState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 enum JBBallotState {
   Active,

--- a/contracts/interfaces/IJBAllowanceTerminal.sol
+++ b/contracts/interfaces/IJBAllowanceTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBAllowanceTerminal {
   function useAllowanceOf(

--- a/contracts/interfaces/IJBController.sol
+++ b/contracts/interfaces/IJBController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBFundAccessConstraints.sol';

--- a/contracts/interfaces/IJBControllerUtility.sol
+++ b/contracts/interfaces/IJBControllerUtility.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBDirectory.sol';
 

--- a/contracts/interfaces/IJBDirectory.sol
+++ b/contracts/interfaces/IJBDirectory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBFundingCycleStore.sol';
 import './IJBPaymentTerminal.sol';

--- a/contracts/interfaces/IJBETHERC20ProjectPayerDeployer.sol
+++ b/contracts/interfaces/IJBETHERC20ProjectPayerDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBDirectory.sol';
 import './IJBProjectPayer.sol';

--- a/contracts/interfaces/IJBETHERC20SplitsPayerDeployer.sol
+++ b/contracts/interfaces/IJBETHERC20SplitsPayerDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBSplitsPayer.sol';
 import './IJBSplitsStore.sol';

--- a/contracts/interfaces/IJBFeeGauge.sol
+++ b/contracts/interfaces/IJBFeeGauge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBFeeGauge {
   function currentDiscountFor(uint256 _projectId) external view returns (uint256);

--- a/contracts/interfaces/IJBFundingCycleBallot.sol
+++ b/contracts/interfaces/IJBFundingCycleBallot.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../enums/JBBallotState.sol';

--- a/contracts/interfaces/IJBFundingCycleDataSource.sol
+++ b/contracts/interfaces/IJBFundingCycleDataSource.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBPayParamsData.sol';
@@ -21,7 +21,7 @@ import './IJBRedemptionDelegate.sol';
   IERC165 for adequate interface integration
 */
 interface IJBFundingCycleDataSource is IERC165 {
-    /**
+  /**
     @notice
     The datasource implementation for JBPaymentTerminal.pay(..)
 

--- a/contracts/interfaces/IJBFundingCycleStore.sol
+++ b/contracts/interfaces/IJBFundingCycleStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../enums/JBBallotState.sol';
 import './../structs/JBFundingCycle.sol';

--- a/contracts/interfaces/IJBMigratable.sol
+++ b/contracts/interfaces/IJBMigratable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBMigratable {
   function prepForMigrationOf(uint256 _projectId, address _from) external;

--- a/contracts/interfaces/IJBOperatable.sol
+++ b/contracts/interfaces/IJBOperatable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBOperatorStore.sol';
 

--- a/contracts/interfaces/IJBOperatorStore.sol
+++ b/contracts/interfaces/IJBOperatorStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../structs/JBOperatorData.sol';
 

--- a/contracts/interfaces/IJBPayDelegate.sol
+++ b/contracts/interfaces/IJBPayDelegate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBDidPayData.sol';

--- a/contracts/interfaces/IJBPaymentTerminal.sol
+++ b/contracts/interfaces/IJBPaymentTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 

--- a/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
+++ b/contracts/interfaces/IJBPayoutRedemptionPaymentTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import './../structs/JBFee.sol';

--- a/contracts/interfaces/IJBPayoutTerminal.sol
+++ b/contracts/interfaces/IJBPayoutTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBPayoutTerminal {
   function distributePayoutsOf(

--- a/contracts/interfaces/IJBPriceFeed.sol
+++ b/contracts/interfaces/IJBPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBPriceFeed {
   function currentPrice(uint256 _targetDecimals) external view returns (uint256);

--- a/contracts/interfaces/IJBPrices.sol
+++ b/contracts/interfaces/IJBPrices.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBPriceFeed.sol';
 

--- a/contracts/interfaces/IJBProjectPayer.sol
+++ b/contracts/interfaces/IJBProjectPayer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './IJBDirectory.sol';

--- a/contracts/interfaces/IJBProjects.sol
+++ b/contracts/interfaces/IJBProjects.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import './../structs/JBProjectMetadata.sol';

--- a/contracts/interfaces/IJBReconfigurationBufferBallot.sol
+++ b/contracts/interfaces/IJBReconfigurationBufferBallot.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBFundingCycleBallot.sol';
 

--- a/contracts/interfaces/IJBRedemptionDelegate.sol
+++ b/contracts/interfaces/IJBRedemptionDelegate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBDidRedeemData.sol';
@@ -16,7 +16,7 @@ import './../structs/JBDidRedeemData.sol';
   IERC165 for adequate interface integration
 */
 interface IJBRedemptionDelegate is IERC165 {
-    /**
+  /**
     @notice
     This function is called by JBPaymentTerminal.redeemTokensOf(..), after the execution of its logic
 

--- a/contracts/interfaces/IJBRedemptionTerminal.sol
+++ b/contracts/interfaces/IJBRedemptionTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBRedemptionTerminal {
   function redeemTokensOf(

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminal.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBPaymentTerminal.sol';
 

--- a/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
+++ b/contracts/interfaces/IJBSingleTokenPaymentTerminalStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../structs/JBFundingCycle.sol';
 import './../structs/JBTokenAmount.sol';

--- a/contracts/interfaces/IJBSplitAllocator.sol
+++ b/contracts/interfaces/IJBSplitAllocator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import '../structs/JBSplitAllocationData.sol';

--- a/contracts/interfaces/IJBSplitsPayer.sol
+++ b/contracts/interfaces/IJBSplitsPayer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './../structs/JBSplit.sol';

--- a/contracts/interfaces/IJBSplitsStore.sol
+++ b/contracts/interfaces/IJBSplitsStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../structs/JBGroupedSplits.sol';
 import './../structs/JBSplit.sol';

--- a/contracts/interfaces/IJBTerminalUtility.sol
+++ b/contracts/interfaces/IJBTerminalUtility.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBDirectory.sol';
 

--- a/contracts/interfaces/IJBToken.sol
+++ b/contracts/interfaces/IJBToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBToken {
   function decimals() external view returns (uint8);

--- a/contracts/interfaces/IJBTokenStore.sol
+++ b/contracts/interfaces/IJBTokenStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './IJBProjects.sol';
 import './IJBToken.sol';

--- a/contracts/interfaces/IJBTokenUriResolver.sol
+++ b/contracts/interfaces/IJBTokenUriResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 interface IJBTokenUriResolver {
   function getUri(uint256 _projectId) external view returns (string memory tokenUri);

--- a/contracts/libraries/JBConstants.sol
+++ b/contracts/libraries/JBConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 /**
   @notice

--- a/contracts/libraries/JBCurrencies.sol
+++ b/contracts/libraries/JBCurrencies.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 library JBCurrencies {
   uint256 public constant ETH = 1;

--- a/contracts/libraries/JBFixedPointNumber.sol
+++ b/contracts/libraries/JBFixedPointNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 library JBFixedPointNumber {
   function adjustDecimals(

--- a/contracts/libraries/JBFundingCycleMetadataResolver.sol
+++ b/contracts/libraries/JBFundingCycleMetadataResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBFundingCycleDataSource.sol';
 import './../structs/JBFundingCycleMetadata.sol';

--- a/contracts/libraries/JBGlobalFundingCycleMetadataResolver.sol
+++ b/contracts/libraries/JBGlobalFundingCycleMetadataResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBFundingCycleDataSource.sol';
 import './../structs/JBFundingCycleMetadata.sol';

--- a/contracts/libraries/JBOperations.sol
+++ b/contracts/libraries/JBOperations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 library JBOperations {
   uint256 public constant RECONFIGURE = 1;

--- a/contracts/libraries/JBSplitsGroups.sol
+++ b/contracts/libraries/JBSplitsGroups.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 library JBSplitsGroups {
   uint256 public constant ETH_PAYOUT = 1;

--- a/contracts/libraries/JBTokens.sol
+++ b/contracts/libraries/JBTokens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 library JBTokens {
   /** 

--- a/contracts/structs/JBDidPayData.sol
+++ b/contracts/structs/JBDidPayData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './JBTokenAmount.sol';
 

--- a/contracts/structs/JBDidRedeemData.sol
+++ b/contracts/structs/JBDidRedeemData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './JBTokenAmount.sol';
 

--- a/contracts/structs/JBFee.sol
+++ b/contracts/structs/JBFee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 /** 
   @member amount The total amount the fee was taken from, as a fixed point number with the same number of decimals as the terminal in which this struct was created.

--- a/contracts/structs/JBFundAccessConstraints.sol
+++ b/contracts/structs/JBFundAccessConstraints.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBPaymentTerminal.sol';
 

--- a/contracts/structs/JBFundingCycle.sol
+++ b/contracts/structs/JBFundingCycle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBFundingCycleBallot.sol';
 

--- a/contracts/structs/JBFundingCycleData.sol
+++ b/contracts/structs/JBFundingCycleData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBFundingCycleBallot.sol';
 

--- a/contracts/structs/JBFundingCycleMetadata.sol
+++ b/contracts/structs/JBFundingCycleMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './JBGlobalFundingCycleMetadata.sol';
 import './../interfaces/IJBFundingCycleDataSource.sol';

--- a/contracts/structs/JBGlobalFundingCycleMetadata.sol
+++ b/contracts/structs/JBGlobalFundingCycleMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBFundingCycleDataSource.sol';
 

--- a/contracts/structs/JBGroupedSplits.sol
+++ b/contracts/structs/JBGroupedSplits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './JBSplit.sol';
 

--- a/contracts/structs/JBOperatorData.sol
+++ b/contracts/structs/JBOperatorData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 /** 
   @member operator The address of the operator.

--- a/contracts/structs/JBPayParamsData.sol
+++ b/contracts/structs/JBPayParamsData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBPaymentTerminal.sol';
 import './JBTokenAmount.sol';

--- a/contracts/structs/JBProjectMetadata.sol
+++ b/contracts/structs/JBProjectMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 /** 
   @member content The metadata content.

--- a/contracts/structs/JBRedeemParamsData.sol
+++ b/contracts/structs/JBRedeemParamsData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBPaymentTerminal.sol';
 import './JBTokenAmount.sol';

--- a/contracts/structs/JBSplit.sol
+++ b/contracts/structs/JBSplit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './../interfaces/IJBSplitAllocator.sol';
 

--- a/contracts/structs/JBSplitAllocationData.sol
+++ b/contracts/structs/JBSplitAllocationData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 import './JBSplit.sol';
 

--- a/contracts/structs/JBTokenAmount.sol
+++ b/contracts/structs/JBTokenAmount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.0;
 
 /* 
   @member token The token the payment was made in.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/jbx-protocol/juice-contracts-v2"
   },
-  "version": "8.0.2",
+  "version": "8.0.3",
   "license": "MIT",
   "devDependencies": {
     "@chainlink/contracts": "^0.1.6",


### PR DESCRIPTION
Improve compatibility with other repos reusing our interfaces or constant, by setting solc to ^0.8.0 (no version change for us as main contracts stay ==0.8.16)