### PR TITLE
revise JBETHERC20ProjetPayer pragma

### DIFF
--- a/contracts/JBETHERC20ProjectPayer.sol
+++ b/contracts/JBETHERC20ProjectPayer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 import '@openzeppelin/contracts/utils/introspection/ERC165.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';


### PR DESCRIPTION
idk if we're still maintaining this repo, but i needed to change this file from `0.8.6` to `^0.8.6` to use modern versions of solidity that have other features I wanted. 

I *think* this change is no problem, as there's no library or factory dependencies here and i'm redeploying the affected file myself (and so would anyone else, i believe). 